### PR TITLE
UISINVCOMP-6  Don't add `typeId` param to facets when Classification Browse doesn't have assigned types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - [UISINVCOMP-4](https://issues.folio.org/browse/UISINVCOMP-4) Move AdvancedSearch utility to stripes-inventory-components module.
 - [UISINVCOMP-2](https://issues.folio.org/browse/UISINVCOMP-2) Move search and facets functionality into this module to be used by both ui-inventory and ui-plugin-find-instance.
 - [UISINVCOMP-5](https://issues.folio.org/browse/UISINVCOMP-5) Rewrite facets functionality (useFacets, withFacets).
+- [UISINVCOMP-6](https://issues.folio.org/browse/UISINVCOMP-6) Don't add `typeId` param to facets when Classification Browse doesn't have assigned types

--- a/lib/hooks/useFacets/useFacets.test.js
+++ b/lib/hooks/useFacets/useFacets.test.js
@@ -69,6 +69,9 @@ const locations = [
 const classificationBrowseConfig = [{
   id: 'lc',
   typeIds: ['type-1', 'type-2'],
+}, {
+  id: 'dewey',
+  typeIds: [],
 }];
 
 const data = {
@@ -433,33 +436,67 @@ describe('useFacets', () => {
   });
 
   describe('when opening classification browse shared facet', () => {
-    it('should make a request with correct search params', async () => {
-      json.mockResolvedValue({ facets: effectiveLocationResponse });
+    describe('when Classification Browse has assigned types', () => {
+      it('should make a request with correct search params', async () => {
+        json.mockResolvedValue({ facets: effectiveLocationResponse });
 
-      const { result } = renderHook(useFacets, {
-        initialProps: {
-          initialAccordionStates,
-          query: {
-            ...queryObj,
-            qindex: browseClassificationOptions.LC_CLASSIFICATION,
-            filters: '',
+        const { result } = renderHook(useFacets, {
+          initialProps: {
+            initialAccordionStates,
+            query: {
+              ...queryObj,
+              qindex: browseClassificationOptions.LC_CLASSIFICATION,
+              filters: '',
+            },
+            filterConfig,
+            activeFilters,
+            data,
+            isBrowseLookup: true,
           },
-          filterConfig,
-          activeFilters,
-          data,
-          isBrowseLookup: true,
-        },
-        wrapper: Wrapper,
+          wrapper: Wrapper,
+        });
+
+        act(() => result.current.onToggleAccordion({ id: 'shared' }));
+        await act(async () => !result.current.isLoading);
+
+        expect(mockGet).toHaveBeenCalledWith('search/classifications/facets', {
+          searchParams: {
+            facet: `${FACETS_CQL.SHARED}:6`,
+            query: '(cql.allRecords=1) and typeId==("type-1" or "type-2")',
+          },
+        });
       });
+    });
 
-      act(() => result.current.onToggleAccordion({ id: 'shared' }));
-      await act(async () => !result.current.isLoading);
+    describe('when Classification Browse does not have assigned types', () => {
+      it('should make a request without typeId param', async () => {
+        json.mockResolvedValue({ facets: effectiveLocationResponse });
 
-      expect(mockGet).toHaveBeenCalledWith('search/classifications/facets', {
-        searchParams: {
-          facet: `${FACETS_CQL.SHARED}:6`,
-          query: '(cql.allRecords=1) and typeId==("type-1" or "type-2")',
-        },
+        const { result } = renderHook(useFacets, {
+          initialProps: {
+            initialAccordionStates,
+            query: {
+              ...queryObj,
+              qindex: browseClassificationOptions.DEWEY_CLASSIFICATION,
+              filters: '',
+            },
+            filterConfig,
+            activeFilters,
+            data,
+            isBrowseLookup: true,
+          },
+          wrapper: Wrapper,
+        });
+
+        act(() => result.current.onToggleAccordion({ id: 'shared' }));
+        await act(async () => !result.current.isLoading);
+
+        expect(mockGet).toHaveBeenCalledWith('search/classifications/facets', {
+          searchParams: {
+            facet: `${FACETS_CQL.SHARED}:6`,
+            query: '(cql.allRecords=1)',
+          },
+        });
       });
     });
   });

--- a/lib/hooks/useFacets/utils.js
+++ b/lib/hooks/useFacets/utils.js
@@ -101,7 +101,7 @@ export const getCqlQuery = (isBrowseLookup, query, filterConfig, data) => {
         query: queryForBrowseFacets,
         qindex: normalizedFilters.qindex,
         ...otherFilters,
-        ...(isClassificationBrowse && {
+        ...(isClassificationBrowse && classificationBrowseTypes.length && {
           typeId: classificationBrowseTypes,
         }),
       },


### PR DESCRIPTION
## Don't add `typeId` param to facets when Classification Browse doesn't have assigned types

## Issues
[UISINVCOMP-6](https://folio-org.atlassian.net/browse/UISINVCOMP-6)