### PR TITLE
UISINVCOMP-7: `buildSearchQuery` - use the default `qindex` if `queryParams` is not empty and `qindex` is missing (follow-up).

### DIFF
--- a/lib/buildSearchQuery/buildSearchQuery.js
+++ b/lib/buildSearchQuery/buildSearchQuery.js
@@ -1,3 +1,5 @@
+import isEmpty from 'lodash/isEmpty';
+
 import { makeQueryFunction } from '@folio/stripes/smart-components';
 
 import {
@@ -15,11 +17,14 @@ import {
 } from '../constants';
 import { filterConfig } from '../filterConfig';
 
+// For the inventory app, query params are taken from `queryParams`, and for the plugin - from `props.resources.query`.
 export const buildSearchQuery = (applyDefaultStaffSuppressFilter) => (queryParams, pathComponents, resourceData, logger, props) => {
   const segment = queryParams.segment || props.segment || segments.instances;
   const { indexes, sortMap, filters } = filterConfig[segment];
   const query = { ...resourceData.query };
-  const queryIndex = queryParams?.qindex || props?.resources?.query?.qindex || getDefaultQindex(segment);
+  const defaultQindex = getDefaultQindex(segment);
+  const queryIndex = (!isEmpty(queryParams) && (queryParams.qindex || defaultQindex))
+    || props?.resources?.query?.qindex || defaultQindex;
   const queryValue = queryParams?.query || props?.resources?.query?.query || '';
   let queryTemplate = getQueryTemplate(queryIndex, indexes);
 

--- a/lib/buildSearchQuery/buildSearchQuery.test.js
+++ b/lib/buildSearchQuery/buildSearchQuery.test.js
@@ -152,4 +152,124 @@ describe('buildSearchQuery', () => {
       expect(cql).toContain('(subjects.value==/string "Some \\"subject\\" query")');
     });
   });
+
+  describe('inventory app', () => {
+    it('should use qindex from queryParams', () => {
+      const queryParams = {
+        query: 'foo',
+        qindex: queryIndexes.TITLE,
+        filters: 'staffSuppress.false',
+      };
+      const pathComponents = {};
+      const resourceData = {
+        query: {
+          ...queryParams,
+          qindex: '',
+          sort: 'title',
+        },
+      };
+      const logger = { log: noop };
+      const props = {
+        resources: {
+          query: {
+            query: 'foo2',
+            qindex: 'contributors',
+          },
+        },
+      };
+
+      const cql = buildSearchQuery(noop)(queryParams, pathComponents, resourceData, logger, props);
+
+      expect(cql).toContain('((title all "foo") and staffSuppress=="false")');
+    });
+
+    describe('when there is no qindex in queryParmas', () => {
+      it('should use default qindex', () => {
+        const queryParams = {
+          query: 'foo',
+          filters: 'staffSuppress.false',
+        };
+        const pathComponents = {};
+        const resourceData = {
+          query: {
+            ...queryParams,
+            qindex: '',
+            sort: 'title',
+          },
+        };
+        const logger = { log: noop };
+        const props = {
+          resources: {
+            query: {
+              query: 'foo2',
+              qindex: 'contributors',
+            },
+          },
+        };
+
+        const cql = buildSearchQuery(noop)(queryParams, pathComponents, resourceData, logger, props);
+
+        expect(cql).toContain('((keyword all "foo" or isbn="foo" or hrid=="foo" or id=="foo") and staffSuppress=="false")');
+      });
+    });
+  });
+
+  describe('plugin', () => {
+    it('should use qindex from props.resources.query', () => {
+      const query = {
+        qindex: queryIndexes.TITLE,
+        query: 'foo',
+        filters: 'staffSuppress.false',
+      };
+      const queryParams = {};
+      const pathComponents = undefined;
+      const resourceData = {
+        query: {
+          ...query,
+          qindex: '',
+          sort: 'title',
+        },
+      };
+      const logger = { log: noop };
+      const props = {
+        resources: {
+          query,
+        },
+      };
+
+      const cql = buildSearchQuery(noop)(queryParams, pathComponents, resourceData, logger, props);
+
+      expect(cql).toContain('((title all "foo") and staffSuppress=="false")');
+    });
+
+    describe('when there is no qindex in props.resources.query', () => {
+      it('should use default qindex', () => {
+        const query = {
+          qindex: '',
+          query: 'foo',
+          filters: 'staffSuppress.false',
+          sort: 'title',
+        };
+        const queryParams = {};
+        const pathComponents = undefined;
+        const resourceData = {
+          query: {
+            ...query,
+            qindex: '',
+            sort: undefined,
+          },
+        };
+        const logger = { log: noop };
+        const props = {
+          resources: {
+            query,
+          },
+        };
+
+        const cql = buildSearchQuery(noop)(queryParams, pathComponents, resourceData, logger, props);
+
+        expect(cql).toContain('((keyword all "foo" or isbn="foo" or hrid=="foo" or id=="foo") and staffSuppress=="false")');
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
In inventory app, query parameters are taken from `queryParams` and for the plugin from `props.resources.query`. `qindex` may be missing, which means that default `qindex` must be used. 

Before this PR, if `qindex` wasn't found in `queryParams?.qindex`, it was taken from `props?.resources?.query?.qindex` and the `qindex` value was wrong because navigating from the `Browse` search gives `qindex` which is not present in `Search` lookup, so we have to rely only on `queryParams` for inventory app. `queryParams` is always an empty object for plugin, so let's check if `queryParams` is not empty, then use `qindex` from it, and if it is missing, use the default `qindex`.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->

## Issues
[UISINVCOMP-7](https://folio-org.atlassian.net/browse/UISINVCOMP-7)

## Screencast


https://github.com/folio-org/stripes-inventory-components/assets/77053927/112b5462-9927-42f8-8b74-c68a5a9f9259



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
