### PR TITLE
UISINVCOMP-11 Use full-text operators for Place Of publication (follow-up)

### DIFF
--- a/lib/constants/fieldSearchConfigurations.js
+++ b/lib/constants/fieldSearchConfigurations.js
@@ -75,9 +75,9 @@ export const fieldSearchConfigurations = {
   },
   placeOfPublication: {
     exactPhrase: 'publication.place=="%{query.query}"',
-    containsAll: 'publication.place=="%{query.query}"',
+    containsAll: 'publication.place all "%{query.query}"',
     startsWith: 'publication.place=="%{query.query}*"',
-    containsAny: 'publication.place=="%{query.query}"',
+    containsAny: 'publication.place any "%{query.query}"',
   },
   subject: {
     exactPhrase: 'subjects.value=="%{query.query}"',

--- a/lib/filterConfig.js
+++ b/lib/filterConfig.js
@@ -147,7 +147,7 @@ export const queryIndexesMap = {
   [queryIndexes.OCLC]: { label: 'stripes-inventory-components.search.oclc', value: queryIndexes.OCLC, queryTemplate: 'oclc="%{query.query}"' },
   [queryIndexes.INSTANCE_NOTES]: { label: 'stripes-inventory-components.search.instanceNotes', value: queryIndexes.INSTANCE_NOTES, queryTemplate: 'notes.note all "%{query.query}" or administrativeNotes all "%{query.query}"' },
   [queryIndexes.INSTANCE_ADMINISTRATIVE_NOTES]: { label: 'stripes-inventory-components.search.instanceAdministrativeNotes', value: queryIndexes.INSTANCE_ADMINISTRATIVE_NOTES, queryTemplate: 'administrativeNotes all "%{query.query}"' },
-  [queryIndexes.PLACE_OF_PUBLICATION]: { label: 'stripes-inventory-components.search.placeOfPublication', value: queryIndexes.PLACE_OF_PUBLICATION, queryTemplate: 'publication.place=="%{query.query}"' },
+  [queryIndexes.PLACE_OF_PUBLICATION]: { label: 'stripes-inventory-components.search.placeOfPublication', value: queryIndexes.PLACE_OF_PUBLICATION, queryTemplate: 'publication.place all "%{query.query}"' },
   [queryIndexes.SUBJECT]: { label: 'stripes-inventory-components.search.subject', value: queryIndexes.SUBJECT, queryTemplate: 'subjects.value==/string "%{query.query}"' },
   [queryIndexes.CALL_NUMBER]: { label: 'stripes-inventory-components.search.effectiveCallNumberShelving', value: queryIndexes.CALL_NUMBER, queryTemplate: 'itemEffectiveShelvingOrder==/string "%{query.query}"' },
   [queryIndexes.INSTANCE_HRID]: { label: 'stripes-inventory-components.search.instanceHrid', value: queryIndexes.INSTANCE_HRID, queryTemplate: 'hrid=="%{query.query}"' },


### PR DESCRIPTION
## Description
`mod-search` docs incorrectly marked `publication.place` as a term-field, when it is a full-text field.
Need to update search operators to match full-text search logic

## Issues
[UISINVCOMP-11](https://folio-org.atlassian.net/browse/UISINVCOMP-11)