### PR TITLE
UISINVCOMP-13: Add `withSearchErrors` to show error messages related to exceeding the request URL limit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@
 - [UISINVCOMP-10](https://issues.folio.org/browse/UISINVCOMP-10) Add "Place of publication" search option.
 - [UISINVCOMP-11](https://issues.folio.org/browse/UISINVCOMP-11) Add "Place of publication" search option to Advanced Search.
 - [UISINVCOMP-12](https://issues.folio.org/browse/UISINVCOMP-12) Add `holdingsId` to the `holdingIndexes` to display the `Holdings UUID` search option.
-- [UISINVCOMP-12](https://issues.folio.org/browse/UISINVCOMP-13) Add `withSearchErrors` to show error messages related to exceeding the request URL limit.
+- [UISINVCOMP-12](https://issues.folio.org/browse/UISINVCOMP-13) Add `withSearchErrors` to display error messages related to exceeding the request URL limit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - [UISINVCOMP-10](https://issues.folio.org/browse/UISINVCOMP-10) Add "Place of publication" search option.
 - [UISINVCOMP-11](https://issues.folio.org/browse/UISINVCOMP-11) Add "Place of publication" search option to Advanced Search.
 - [UISINVCOMP-12](https://issues.folio.org/browse/UISINVCOMP-12) Add `holdingsId` to the `holdingIndexes` to display the `Holdings UUID` search option.
+- [UISINVCOMP-12](https://issues.folio.org/browse/UISINVCOMP-13) Add `withSearchErrors` to show error messages related to exceeding the request URL limit.

--- a/lib/buildRecordsManifest/buildRecordsManifest.js
+++ b/lib/buildRecordsManifest/buildRecordsManifest.js
@@ -1,0 +1,21 @@
+import { buildSearchQuery } from '../buildSearchQuery';
+
+export const buildRecordsManifest = (applyDefaultStaffSuppressFilter) => {
+  return {
+    type: 'okapi',
+    records: 'instances',
+    resultOffset: '%{resultOffset}',
+    perRequest: 100,
+    throwErrors: false,
+    path: 'inventory/instances',
+    resultDensity: 'sparse',
+    accumulate: 'true',
+    GET: {
+      path: 'search/instances',
+      params: {
+        expandAll: true,
+        query: buildSearchQuery(applyDefaultStaffSuppressFilter),
+      },
+    },
+  };
+};

--- a/lib/buildRecordsManifest/index.js
+++ b/lib/buildRecordsManifest/index.js
@@ -1,0 +1,1 @@
+export * from './buildRecordsManifest';

--- a/lib/buildSearchQuery/buildSearchQuery.js
+++ b/lib/buildSearchQuery/buildSearchQuery.js
@@ -63,7 +63,7 @@ export const buildSearchQuery = (applyDefaultStaffSuppressFilter) => (queryParam
   // makeQueryFunction escapes quote and backslash characters by default,
   // but when submitting a raw CQL query (i.e. when queryIndex === 'querySearch')
   // we assume the user knows what they are doing and wants to run the CQL as-is.
-  return makeQueryFunction(
+  const requestUrlQuery = makeQueryFunction(
     CQL_FIND_ALL,
     queryTemplate,
     sortMap,
@@ -72,4 +72,8 @@ export const buildSearchQuery = (applyDefaultStaffSuppressFilter) => (queryParam
     null,
     queryIndex !== queryIndexes.QUERY_SEARCH,
   )(queryParams, pathComponents, resourceData, logger, props);
+
+  props.mutator.requestUrlQuery.replace(requestUrlQuery);
+
+  return requestUrlQuery;
 };

--- a/lib/buildSearchQuery/buildSearchQuery.test.js
+++ b/lib/buildSearchQuery/buildSearchQuery.test.js
@@ -7,12 +7,21 @@ import buildStripes from '../../test/jest/__mock__/stripesCore.mock';
 
 const getQueryTemplate = (qindex) => instanceIndexes.find(({ value }) => value === qindex).queryTemplate;
 
+const mockReplaceRequestUrlQuery = jest.fn();
+
+const defaultProps = {
+  stripes: buildStripes(),
+  mutator: {
+    requestUrlQuery: { replace: mockReplaceRequestUrlQuery },
+  },
+};
+
 const getBuildQueryArgs = ({
   queryParams = {},
   pathComponents = {},
   resourceData = {},
   logger = { log: jest.fn() },
-  props = { stripes: buildStripes() }
+  props = defaultProps,
 } = {}) => {
   const resData = { query: { ...queryParams }, ...resourceData };
 
@@ -26,6 +35,10 @@ const defaultQueryParamsMap = {
 };
 
 describe('buildSearchQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('build query for inventory search', () => {
     it('should build query for \'Effective call number (item), shelving order\' search option', () => {
       const qindex = queryIndexes.CALL_NUMBER;
@@ -170,6 +183,7 @@ describe('buildSearchQuery', () => {
       };
       const logger = { log: noop };
       const props = {
+        ...defaultProps,
         resources: {
           query: {
             query: 'foo2',
@@ -199,6 +213,7 @@ describe('buildSearchQuery', () => {
         };
         const logger = { log: noop };
         const props = {
+          ...defaultProps,
           resources: {
             query: {
               query: 'foo2',
@@ -232,6 +247,7 @@ describe('buildSearchQuery', () => {
       };
       const logger = { log: noop };
       const props = {
+        ...defaultProps,
         resources: {
           query,
         },
@@ -261,6 +277,7 @@ describe('buildSearchQuery', () => {
         };
         const logger = { log: noop };
         const props = {
+          ...defaultProps,
           resources: {
             query,
           },
@@ -271,5 +288,12 @@ describe('buildSearchQuery', () => {
         expect(cql).toContain('((keyword all "foo" or isbn="foo" or hrid=="foo" or id=="foo") and staffSuppress=="false")');
       });
     });
+  });
+
+  it('should replace request url query', () => {
+    const queryParams = { ...defaultQueryParamsMap[queryIndexes.CONTRIBUTOR] };
+    const cql = buildSearchQuery(noop)(...getBuildQueryArgs({ queryParams }));
+
+    expect(mockReplaceRequestUrlQuery).toHaveBeenCalledWith(cql);
   });
 });

--- a/lib/components/CheckboxFacet/CheckboxFacet.js
+++ b/lib/components/CheckboxFacet/CheckboxFacet.js
@@ -33,7 +33,7 @@ class CheckboxFacetComponent extends React.Component {
   static defaultProps = {
     selectedValues: [],
     isFilterable: false,
-  }
+  };
 
   state = {
     more: SHOW_OPTIONS_COUNT,
@@ -101,7 +101,7 @@ class CheckboxFacetComponent extends React.Component {
     this.setState(({ more }) => {
       return { more: more + SHOW_OPTIONS_INCREMENT };
     });
-  }
+  };
 
   render() {
     const {

--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -5,6 +5,7 @@ export const LIMIT_MAX = 5000;
 export const OKAPI_TENANT_HEADER = 'X-Okapi-Tenant';
 export const QUERY_KEY_LOCATIONS_FROM_ALL_TENANTS = 'locations-from-all-tenants';
 export const DEFAULT_SORT = 'title';
+export const FAILED_TO_FETCH_ERROR = 'Failed to fetch';
 
 export const segments = {
   instances: 'instances',

--- a/lib/hocs/index.js
+++ b/lib/hocs/index.js
@@ -1,0 +1,1 @@
+export * from './withSearchErrors';

--- a/lib/hocs/withSearchErrors/index.js
+++ b/lib/hocs/withSearchErrors/index.js
@@ -1,0 +1,1 @@
+export * from './withSearchErrors';

--- a/lib/hocs/withSearchErrors/withSearchErrors.js
+++ b/lib/hocs/withSearchErrors/withSearchErrors.js
@@ -1,0 +1,63 @@
+import {
+  useEffect,
+  useState,
+} from 'react';
+import { useIntl } from 'react-intl';
+
+import {
+  useCallout,
+  useStripes,
+} from '@folio/stripes/core';
+
+import PropTypes from 'prop-types';
+import { processSearchErrors } from '../../utils';
+
+const withSearchErrors = (WrappedComponent) => {
+  const SearchErrors = (props) => {
+    const intl = useIntl();
+    const callout = useCallout();
+    const stripes = useStripes();
+
+    const [isRequestUrlExceededLimit, setIsRequestUrlExceededLimit] = useState(false);
+
+    const error = props.resources.records.failed;
+    const host = stripes.okapi.url;
+    const recordsManifest = WrappedComponent.manifest.records;
+    const pathname = recordsManifest.GET.path;
+    const manifestParams = recordsManifest.GET.params;
+    const limit = recordsManifest.perRequest;
+    const requestUrlQuery = props.resources.requestUrlQuery;
+
+    useEffect(() => {
+      if (error) {
+        const params = {
+          ...manifestParams,
+          query: requestUrlQuery,
+          limit,
+        };
+
+        processSearchErrors({ error, callout, intl, pathname, host, params, setIsRequestUrlExceededLimit });
+      } else {
+        setIsRequestUrlExceededLimit(false);
+      }
+      // `manifestParams` is always a new object, and it is constant, so we can ignore it in deps. Otherwise,
+      // an error toast will be displayed even if there is no error.
+    }, [processSearchErrors, error, callout, intl, pathname, host, requestUrlQuery, limit]);
+
+    return (
+      <WrappedComponent
+        {...props}
+        isRequestUrlExceededLimit={isRequestUrlExceededLimit}
+      />
+    );
+  };
+
+  SearchErrors.manifest = WrappedComponent.manifest;
+  SearchErrors.propTypes = {
+    resources: PropTypes.object.isRequired,
+  };
+
+  return SearchErrors;
+};
+
+export { withSearchErrors };

--- a/lib/hocs/withSearchErrors/withSearchErrors.test.js
+++ b/lib/hocs/withSearchErrors/withSearchErrors.test.js
@@ -1,0 +1,146 @@
+import noop from 'lodash/noop';
+
+import { REQUEST_URL_LIMIT } from '@folio/stripes/smart-components';
+import stripesSmartComponentsTranslations from '@folio/stripes-smart-components/translations/stripes-smart-components/en';
+import { render } from '@folio/jest-config-stripes/testing-library/react';
+
+import { withSearchErrors } from './withSearchErrors';
+import Harness from '../../../test/jest/helpers/Harness';
+import { FAILED_TO_FETCH_ERROR } from '../../constants';
+import { buildRecordsManifest } from '../../buildRecordsManifest';
+
+const mockSendCallout = jest.fn();
+const mockWrappedComponent = jest.fn();
+mockWrappedComponent.manifest = {
+  records: buildRecordsManifest(noop),
+};
+
+const SearchErrors = withSearchErrors(mockWrappedComponent);
+
+const translations = [{
+  prefix: 'stripes-smart-components',
+  translations: stripesSmartComponentsTranslations,
+}];
+const urlLimitExceeded = `Search URI request character limit has been exceeded. The character limit is ${REQUEST_URL_LIMIT}. Please revise your search and/or facet selections.`;
+const resources = {
+  requestUrlQuery: 'request query',
+  records: {
+    failed: false,
+  },
+};
+
+const getComponent = (props = {}, { showToast } = {}) => (
+  <Harness
+    sendCallout={mockSendCallout}
+    translations={translations}
+  >
+    <SearchErrors
+      resources={resources}
+      {...props}
+    />
+    {showToast && (
+      <div id="callout-1">
+        {urlLimitExceeded}
+      </div>
+    )}
+  </Harness>
+);
+
+const renderSearchErrors = (props, options) => render(getComponent(props, options));
+
+describe('withSearchErrors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when there is the "Failed to fetch" error and request URL exceeded limit', () => {
+    it('should display the error message', () => {
+      renderSearchErrors({
+        resources: {
+          records: {
+            failed: {
+              message: FAILED_TO_FETCH_ERROR,
+            },
+          },
+          requestUrlQuery: 'some long string to trigger the error',
+        },
+      });
+
+      expect(mockSendCallout).toHaveBeenCalledWith({
+        message: urlLimitExceeded,
+        type: 'error',
+      });
+    });
+  });
+
+  describe('when there is the "Failed to fetch" error for both records and facets', () => {
+    it('should display the error message once', () => {
+      renderSearchErrors({
+        resources: {
+          records: {
+            failed: {
+              message: FAILED_TO_FETCH_ERROR,
+            },
+          },
+          requestUrlQuery: 'some long string to trigger the error',
+        },
+      }, {
+        showToast: true,
+      });
+
+      expect(mockSendCallout).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should not display an error', () => {
+    renderSearchErrors({
+      resources: {
+        records: {
+          failed: false,
+        },
+      },
+    });
+
+    expect(mockSendCallout).not.toHaveBeenCalled();
+  });
+
+  it('should have the same manifest as wrapped component', () => {
+    renderSearchErrors();
+
+    expect(SearchErrors.manifest).toEqual(mockWrappedComponent.manifest);
+  });
+
+  it('should pass the `isRequestUrlExceededLimit` property correctly', () => {
+    const props = {
+      resources: {
+        records: {
+          failed: {
+            message: FAILED_TO_FETCH_ERROR,
+          },
+        },
+        requestUrlQuery: 'some long string to trigger the error',
+      },
+    };
+    const { rerender } = renderSearchErrors(props);
+
+    expect(mockWrappedComponent).toHaveBeenLastCalledWith({
+      ...props,
+      isRequestUrlExceededLimit: true,
+    }, {});
+
+    const props2 = {
+      resources: {
+        records: {
+          failed: false,
+        },
+      },
+    };
+
+    rerender(getComponent(props2));
+
+    expect(mockWrappedComponent).toHaveBeenLastCalledWith({
+      ...props2,
+      isRequestUrlExceededLimit: false,
+    }, {});
+  });
+});

--- a/lib/hooks/useFacets/useFacetsQuery/useFacetsQuery.js
+++ b/lib/hooks/useFacets/useFacetsQuery/useFacetsQuery.js
@@ -1,9 +1,12 @@
 import { useState } from 'react';
 import { useQuery } from 'react-query';
+import { useIntl } from 'react-intl';
 
 import {
   useOkapiKy,
   useNamespace,
+  useCallout,
+  useStripes,
 } from '@folio/stripes/core';
 
 import {
@@ -11,14 +14,20 @@ import {
   browseModeOptions,
   FACETS_KEY,
 } from '../../../constants';
+import { processSearchErrors } from '../../../utils';
 
 const useFacetsQuery = ({ qindex, searchParams, onSettled }) => {
   const { query, facet } = searchParams;
 
   const ky = useOkapiKy();
+  const stripes = useStripes();
+  const callout = useCallout();
+  const intl = useIntl();
   const [namespace] = useNamespace({ key: FACETS_KEY });
 
   const [allData, setAllData] = useState({});
+
+  const host = stripes.okapi.url;
 
   const getPath = () => {
     if (qindex === browseModeOptions.CONTRIBUTORS) {
@@ -31,14 +40,18 @@ const useFacetsQuery = ({ qindex, searchParams, onSettled }) => {
     return 'search/instances/facets';
   };
 
+  const getSearchParams = () => {
+    return {
+      facet,
+      query: query || 'id=*',
+    };
+  };
+
   const { isFetching } = useQuery(
     [namespace, searchParams],
     async () => {
       const data = await ky.get(getPath(), {
-        searchParams: {
-          facet,
-          query: query || 'id=*',
-        },
+        searchParams: getSearchParams(),
       }).json();
 
       // Collect data here since useQuery only returns data from the last call if a new request is made while
@@ -50,6 +63,16 @@ const useFacetsQuery = ({ qindex, searchParams, onSettled }) => {
     {
       enabled: Boolean(facet),
       onSettled,
+      onError: error => {
+        processSearchErrors({
+          error,
+          callout,
+          intl,
+          pathname: getPath(),
+          host,
+          params: getSearchParams(),
+        });
+      },
     }
   );
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,3 +6,5 @@ export * from './hooks';
 export * from './queries';
 export * from './filterConfig';
 export * from './buildSearchQuery';
+export * from './hocs';
+export * from './buildRecordsManifest';

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -1,11 +1,17 @@
 import template from 'lodash/template';
+import noop from 'lodash/noop';
 
-import { advancedSearchQueryToRows } from '@folio/stripes/smart-components';
+import {
+  advancedSearchQueryToRows,
+  REQUEST_URL_LIMIT,
+} from '@folio/stripes/smart-components';
 
+import queryString from 'query-string';
 import {
   queryIndexes,
   fieldSearchConfigurations,
   segments,
+  FAILED_TO_FETCH_ERROR,
 } from '../constants';
 
 /**
@@ -102,3 +108,30 @@ export function getIsbnIssnTemplate(queryTemplate, identifierTypes, queryIndex) 
 
   return template(queryTemplate)({ identifierTypeId });
 }
+
+export const getRequestUrlLength = (pathname, host, params) => {
+  const url = new URL(pathname, host);
+  const searchParams = queryString.stringify(params);
+
+  url.search = searchParams.toString();
+
+  return url.toString().length;
+};
+
+export const processSearchErrors = ({ error, callout, intl, pathname, host, params, setIsRequestUrlExceededLimit = noop }) => {
+  if (error.message === FAILED_TO_FETCH_ERROR && getRequestUrlLength(pathname, host, params) > REQUEST_URL_LIMIT) {
+    const message = intl.formatMessage({ id: 'stripes-smart-components.error.requestUrlLimit' }, { limit: REQUEST_URL_LIMIT });
+    const toasts = [...document.querySelectorAll('[id^="callout-"]')];
+    const hasAlreadyShown = toasts.some(toast => toast.textContent === message);
+
+    setIsRequestUrlExceededLimit(true);
+
+    // prevent displaying two identical error messages when both records and facets return it
+    if (hasAlreadyShown) return;
+
+    callout.sendCallout({
+      type: 'error',
+      message,
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "history": "^4.10.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
+    "query-string": "^5.0.0",
     "zustand": "^4.1.1"
   },
   "peerDependencies": {

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -29,6 +29,7 @@ jest.mock('@folio/stripes/smart-components', () => ({
         'description': 'Storage B description'
       }
     });
-  }
+  },
+  REQUEST_URL_LIMIT: 130, // cut down limit for simplicity
 }), { virtual: true });
 

--- a/test/jest/helpers/Harness.js
+++ b/test/jest/helpers/Harness.js
@@ -17,6 +17,7 @@ const client = new QueryClient();
 const Harness = ({
   children,
   translations: translationsConfig,
+  sendCallout = noop,
 }) => {
   const allTranslations = prefixKeys(translations);
 
@@ -32,7 +33,7 @@ const Harness = ({
 
   return (
     <QueryClientProvider client={client}>
-      <CalloutContext.Provider value={{ sendCallout: () => { } }}>
+      <CalloutContext.Provider value={{ sendCallout }}>
         <IntlProvider
           locale="en"
           key="en"


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
When the request URL exceeds the limit:
1. Show an error toast message;
2. Show a specific error message inside the results list.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->

## Approach
1. Create the `withSearchErrors` HOC for use in both `ui-inventory` and `ui-plugin-find-instance`.
2. Add the `isRequestUrlExceededLimit` property in the newly created `withSearchErrors` HOC and based on it return the error message in `failureMessage` of `StripesConnectedSource` in `stripes-smart-components`.

The tests will pass once the related PRs are merged.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1496

## Issues
[UISINVCOMP-13](https://folio-org.atlassian.net/browse/UISINVCOMP-13)

## Screencast
https://github.com/user-attachments/assets/6a60bced-cbc3-4d86-b78e-efe99428f664

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
