### PR TITLE
UISINVCOMP-20 Inventory date range filter: Allow date range filter to only require a From date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,4 @@
 - [UISINVCOMP-17](https://issues.folio.org/browse/UISINVCOMP-17) Create `useDisplaySettingsQuery` and add it to the `useCommonData` hook; add optional `settings` okapi interface.
 - [UISINVCOMP-19](https://issues.folio.org/browse/UISINVCOMP-19) Create `useInstanceDateTypes` and add it to the `useCommonData` hook.
 - [UISINVCOMP-18](https://issues.folio.org/browse/UISINVCOMP-18) Add search results list constants.
-- [UISINVCOMP-20](https://issues.folio.org/browse/UISINVCOMP-20) Make date range filters work without a to date
+- [UISINVCOMP-20](https://issues.folio.org/browse/UISINVCOMP-20) Make date range filters work with just a single from/to date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - [UISINVCOMP-17](https://issues.folio.org/browse/UISINVCOMP-17) Create `useDisplaySettingsQuery` and add it to the `useCommonData` hook; add optional `settings` okapi interface.
 - [UISINVCOMP-19](https://issues.folio.org/browse/UISINVCOMP-19) Create `useInstanceDateTypes` and add it to the `useCommonData` hook.
 - [UISINVCOMP-18](https://issues.folio.org/browse/UISINVCOMP-18) Add search results list constants.
+- [UISINVCOMP-20](https://issues.folio.org/browse/UISINVCOMP-20) Make date range filters work without a to date

--- a/lib/components/DateRange/DateRange.js
+++ b/lib/components/DateRange/DateRange.js
@@ -23,7 +23,7 @@ const propTypes = {
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
-const requiredFields = [DATE_TYPES.START];
+const requiredFields = [];
 
 const DateRange = ({
   name,

--- a/lib/components/DateRange/DateRange.js
+++ b/lib/components/DateRange/DateRange.js
@@ -23,6 +23,8 @@ const propTypes = {
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
+const requiredFields = [DATE_TYPES.START];
+
 const DateRange = ({
   name,
   closedByDefault = true,
@@ -85,7 +87,7 @@ const DateRange = ({
         selectedValues={retrieveDatesFromDateRangeFilterString(activeFilters[name]?.[0])}
         onChange={handleDateRangeChange}
         makeFilterString={makeFilterString}
-        requiredFields={[DATE_TYPES.START]}
+        requiredFields={requiredFields}
       />
     </Accordion>
   );

--- a/lib/components/DateRange/DateRange.js
+++ b/lib/components/DateRange/DateRange.js
@@ -8,7 +8,10 @@ import {
   FilterAccordionHeader,
   dayjs,
 } from '@folio/stripes/components';
-import { DateRangeFilter } from '@folio/stripes/smart-components';
+import {
+  DateRangeFilter,
+  DATE_TYPES,
+} from '@folio/stripes/smart-components';
 
 const propTypes = {
   activeFilters: PropTypes.object.isRequired,
@@ -82,6 +85,7 @@ const DateRange = ({
         selectedValues={retrieveDatesFromDateRangeFilterString(activeFilters[name]?.[0])}
         onChange={handleDateRangeChange}
         makeFilterString={makeFilterString}
+        requiredFields={[DATE_TYPES.START]}
       />
     </Accordion>
   );

--- a/lib/filterConfig.js
+++ b/lib/filterConfig.js
@@ -7,16 +7,20 @@ import {
   segments,
 } from './constants';
 
-const buildDateRangeQuery = name => values => {
+export const buildDateRangeQuery = name => values => {
   const DATE_TIME_RANGE_FILTER_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSS';
   const [startDateString, endDateString] = values[0]?.split(':') || [];
 
-  if (!startDateString || !endDateString) return '';
+  if (!startDateString) {
+    return '';
+  }
 
   const start = dayjs(startDateString).startOf('day').utc().format(DATE_TIME_RANGE_FILTER_FORMAT);
   const end = dayjs(endDateString).endOf('day').utc().format(DATE_TIME_RANGE_FILTER_FORMAT);
 
-  return `${name}>="${start}" and ${name}<="${end}"`;
+  const queryParts = [`${name}>="${start}"`, endDateString ? `${name}<="${end}"` : null];
+
+  return queryParts.filter(el => !!el).join(' and ');
 };
 
 export const filterConfigMap = {

--- a/lib/filterConfig.js
+++ b/lib/filterConfig.js
@@ -11,14 +11,14 @@ export const buildDateRangeQuery = name => values => {
   const DATE_TIME_RANGE_FILTER_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSS';
   const [startDateString, endDateString] = values[0]?.split(':') || [];
 
-  if (!startDateString) {
+  if (!startDateString && !endDateString) {
     return '';
   }
 
   const start = dayjs(startDateString).startOf('day').utc().format(DATE_TIME_RANGE_FILTER_FORMAT);
   const end = dayjs(endDateString).endOf('day').utc().format(DATE_TIME_RANGE_FILTER_FORMAT);
 
-  const queryParts = [`${name}>="${start}"`, endDateString ? `${name}<="${end}"` : null];
+  const queryParts = [startDateString ? `${name}>="${start}"` : null, endDateString ? `${name}<="${end}"` : null];
 
   return queryParts.filter(el => !!el).join(' and ');
 };

--- a/lib/filterConfig.test.js
+++ b/lib/filterConfig.test.js
@@ -1,0 +1,32 @@
+import { buildDateRangeQuery } from './filterConfig';
+
+describe('filterConfig', () => {
+  describe('buildDateRangeQuery', () => {
+    describe('when from date is missing', () => {
+      it('should return an empty string', () => {
+        const name = 'createdDate';
+        const values = [''];
+
+        expect(buildDateRangeQuery(name)(values)).toEqual('');
+      });
+    });
+
+    describe('when to date is missing', () => {
+      it('should return filter with only a from date', () => {
+        const name = 'createdDate';
+        const values = ['01-01-1970'];
+
+        expect(buildDateRangeQuery(name)(values)).toMatch(/createdDate>=[^\s]+/);
+      });
+    });
+
+    describe('when from and to date are present', () => {
+      it('should return filter with both dates', () => {
+        const name = 'createdDate';
+        const values = ['01-01-1970:01-01-1971'];
+
+        expect(buildDateRangeQuery(name)(values)).toMatch(/createdDate>=[^\s]+ and createdDate<=[^\s]+/);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
Inventory date range filter: Allow date range filter to work with a single from or to date

## Screenshots

https://github.com/user-attachments/assets/1cdface0-e6b2-481c-9fda-b27528ec62d4

## Issues
[UISINVCOMP-20](https://folio-org.atlassian.net/browse/UISINVCOMP-20)

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1512