### PR TITLE
UISINVCOMP-29 Fix `<DateRangeFilter>` validation errors disappear when another facet value changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@
 - [UISINVCOMP-27](https://issues.folio.org/browse/UISINVCOMP-27) Fix failed unit tests.
 - [UISINVCOMP-26](https://issues.folio.org/browse/UISINVCOMP-26) Add filters for subject source and type to Inventory subject browse.
 - [UISINVCOMP-28](https://issues.folio.org/browse/UISINVCOMP-28) Date filters: Clear dates after pressing the reset search button.
+- [UISINVCOMP-29](https://issues.folio.org/browse/UISINVCOMP-29) Fix `<DateRangeFilter>` validation errors disappear when another facet value changes.

--- a/lib/components/DateFilter/DateFilter.js
+++ b/lib/components/DateFilter/DateFilter.js
@@ -24,7 +24,7 @@ const propTypes = {
   open: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   onClear: PropTypes.func.isRequired,
-  onRetrieveDates: PropTypes.func.isRequired,
+  selectedValues: PropTypes.object.isRequired,
 };
 
 const requiredFields = [];
@@ -38,7 +38,7 @@ const DateFilter = ({
   open,
   onChange,
   onClear,
-  onRetrieveDates,
+  selectedValues,
 }) => {
   const intl = useIntl();
   const startDateInputRef = useRef();
@@ -84,7 +84,7 @@ const DateFilter = ({
         name={name}
         dateFormat={dateFormat}
         hideCalendarButton={hideCalendarButton}
-        selectedValues={onRetrieveDates(activeFilters[name]?.[0])}
+        selectedValues={selectedValues}
         onChange={onChange}
         makeFilterString={makeFilterString}
         requiredFields={requiredFields}

--- a/lib/components/DateIntervalFilter/DateIntervalFilter.js
+++ b/lib/components/DateIntervalFilter/DateIntervalFilter.js
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { useStripes } from '@folio/stripes/core';
@@ -33,7 +33,9 @@ const DateIntervalFilter = ({
     dayjs.tz.setDefault();
   }, [timezone, onChange]);
 
-  const retrieveDates = useCallback(filterValue => {
+  const filterValue = activeFilters[name]?.[0];
+
+  const selectedValues = useMemo(() => {
     let dateRange = {
       startDate: '',
       endDate: '',
@@ -55,7 +57,7 @@ const DateIntervalFilter = ({
     }
 
     return dateRange;
-  }, []);
+  }, [filterValue]);
 
   return (
     <DateFilter
@@ -65,7 +67,7 @@ const DateIntervalFilter = ({
       open={accordionsStatus[name]}
       onChange={handleDateRangeChange}
       onClear={onClear}
-      onRetrieveDates={retrieveDates}
+      selectedValues={selectedValues}
     />
   );
 };

--- a/lib/components/DateTimeRangeFilter/DateTimeRangeFilter.js
+++ b/lib/components/DateTimeRangeFilter/DateTimeRangeFilter.js
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { DateFilter } from '../DateFilter';
@@ -18,14 +18,16 @@ const DateTimeRangeFilter = ({
   onChange,
   onClear,
 }) => {
-  const retrieveDates = useCallback(filterValue => {
+  const filterValue = activeFilters[name]?.[0];
+
+  const selectedValues = useMemo(() => {
     const [startDate, endDate] = filterValue?.split(':') || [];
 
     return {
       startDate: startDate || '',
       endDate: endDate || '',
     };
-  }, []);
+  }, [filterValue]);
 
   return (
     <DateFilter
@@ -36,7 +38,7 @@ const DateTimeRangeFilter = ({
       open={accordionsStatus[name]}
       onChange={onChange}
       onClear={onClear}
-      onRetrieveDates={retrieveDates}
+      selectedValues={selectedValues}
     />
   );
 };


### PR DESCRIPTION
## Description
Fix `<DateRangeFilter>` validation errors disappear when another facet value changes

Memoize `selectedValues` to prevent excessive re-initialization of `<DateRangeFilter>`.

## Screenshots

https://github.com/user-attachments/assets/a5c6a797-4ad0-437f-8eae-c63b36a71199



## Issues
[UISINVCOMP-29](https://folio-org.atlassian.net/browse/UISINVCOMP-29)