### PR TITLE
UISINVCOMP-34: Get all locations in `useCommonData` hook when user is in consortium mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change history for stripes-inventory-components
 
-## 1.0.1 IN PROGRESS
-
-- [UISINVCOMP-34](https://folio-org.atlassian.net/browse/UISINVCOMP-34) Get all locations in useCommonData hook when user is in consortium mode.
-
 ## 1.0.0 IN PROGRESS
 
 - [UISINVCOMP-1](https://issues.folio.org/browse/UISINVCOMP-1) Prepare the module for use.
@@ -34,3 +30,4 @@
 - [UISINVCOMP-29](https://issues.folio.org/browse/UISINVCOMP-29) Fix `<DateRangeFilter>` validation errors disappear when another facet value changes.
 - [UISINVCOMP-32](https://folio-org.atlassian.net/browse/UISINVCOMP-32) Suppress "Shared" facet when user moves holdings/items to another instance.
 - [UISINVCOMP-30](https://issues.folio.org/browse/UISINVCOMP-30) Refactor ui-inventory permissions.
+- [UISINVCOMP-34](https://folio-org.atlassian.net/browse/UISINVCOMP-34) Get all locations in useCommonData hook when user is in consortium mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@
 - [UISINVCOMP-29](https://issues.folio.org/browse/UISINVCOMP-29) Fix `<DateRangeFilter>` validation errors disappear when another facet value changes.
 - [UISINVCOMP-32](https://folio-org.atlassian.net/browse/UISINVCOMP-32) Suppress "Shared" facet when user moves holdings/items to another instance.
 - [UISINVCOMP-30](https://issues.folio.org/browse/UISINVCOMP-30) Refactor ui-inventory permissions.
+- [UISINVCOMP-34](https://folio-org.atlassian.net/browse/UISINVCOMP-34) Get all locations in useCommonData hook when user is in consortium mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-inventory-components
 
+## 1.0.1 IN PROGRESS
+
+- [UISINVCOMP-34](https://folio-org.atlassian.net/browse/UISINVCOMP-34) Get all locations in useCommonData hook when user is in consortium mode.
+
 ## 1.0.0 IN PROGRESS
 
 - [UISINVCOMP-1](https://issues.folio.org/browse/UISINVCOMP-1) Prepare the module for use.
@@ -30,4 +34,3 @@
 - [UISINVCOMP-29](https://issues.folio.org/browse/UISINVCOMP-29) Fix `<DateRangeFilter>` validation errors disappear when another facet value changes.
 - [UISINVCOMP-32](https://folio-org.atlassian.net/browse/UISINVCOMP-32) Suppress "Shared" facet when user moves holdings/items to another instance.
 - [UISINVCOMP-30](https://issues.folio.org/browse/UISINVCOMP-30) Refactor ui-inventory permissions.
-- [UISINVCOMP-34](https://folio-org.atlassian.net/browse/UISINVCOMP-34) Get all locations in useCommonData hook when user is in consortium mode.

--- a/lib/hooks/useCommonData/useCommonData.js
+++ b/lib/hooks/useCommonData/useCommonData.js
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import keyBy from 'lodash/keyBy';
+import uniqBy from 'lodash/uniqBy';
 
 import { useStripes } from '@folio/stripes/core';
 
@@ -51,7 +52,7 @@ const useCommonData = (tenantId) => {
     const loadedData = {};
 
     if (isConsortiaEnv(stripes)) {
-      loadedData.locations = locationsFromAllTenants;
+      loadedData.locations = uniqBy([...locationsFromAllTenants, ...locations], 'id');
       loadedData.consortiaTenants = consortiaTenants;
     } else {
       loadedData.locations = locations;

--- a/lib/queries/useLocationsQuery/useLocationsQuery.js
+++ b/lib/queries/useLocationsQuery/useLocationsQuery.js
@@ -25,7 +25,7 @@ const useLocationsQuery = (options = {}) => {
 
   return ({
     ...query,
-    locations: query.data?.locations,
+    locations: query.data?.locations || [],
   });
 };
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->
* User from central tenant should see the location of member tenant holding and item.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Create new array of unique locations (`locationsFromAllTenants` and `locations`).

## Links
[UISINVCOMP-34](https://folio-org.atlassian.net/browse/UISINVCOMP-34)

## Screenshots

### Before
https://github.com/user-attachments/assets/5463fb9b-1581-4701-a2d7-4e7af12342b0

### After
https://github.com/user-attachments/assets/68ec7de1-bab1-4e87-a2f2-36441f602384


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
