### PR TITLE
UISINVCOMP-35 Apply `ignoreDatesOrder` prop to Date Range filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@
 - [UISINVCOMP-29](https://issues.folio.org/browse/UISINVCOMP-29) Fix `<DateRangeFilter>` validation errors disappear when another facet value changes.
 - [UISINVCOMP-32](https://folio-org.atlassian.net/browse/UISINVCOMP-32) Suppress "Shared" facet when user moves holdings/items to another instance.
 - [UISINVCOMP-30](https://issues.folio.org/browse/UISINVCOMP-30) Refactor ui-inventory permissions.
+- [UISINVCOMP-35](https://issues.folio.org/browse/UISINVCOMP-35) Apply `ignoreDatesOrder` prop to Date Range filter.

--- a/lib/components/DateFilter/DateFilter.js
+++ b/lib/components/DateFilter/DateFilter.js
@@ -20,6 +20,7 @@ const propTypes = {
   closedByDefault: PropTypes.bool,
   dateFormat: PropTypes.string.isRequired,
   hideCalendarButton: PropTypes.bool,
+  ignoreDatesOrder: PropTypes.bool,
   name: PropTypes.string.isRequired,
   open: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
@@ -34,6 +35,7 @@ const DateFilter = ({
   dateFormat,
   closedByDefault = true,
   hideCalendarButton = false,
+  ignoreDatesOrder = false,
   name,
   open,
   onChange,
@@ -90,6 +92,7 @@ const DateFilter = ({
         requiredFields={requiredFields}
         endDateInputRef={endDateInputRef}
         focusRef={startDateInputRef}
+        ignoreDatesOrder={ignoreDatesOrder}
       />
     </Accordion>
   );

--- a/lib/components/DateTimeRangeFilter/DateTimeRangeFilter.js
+++ b/lib/components/DateTimeRangeFilter/DateTimeRangeFilter.js
@@ -34,6 +34,7 @@ const DateTimeRangeFilter = ({
       activeFilters={activeFilters}
       dateFormat="YYYY"
       hideCalendarButton
+      ignoreDatesOrder
       name={name}
       open={accordionsStatus[name]}
       onChange={onChange}


### PR DESCRIPTION
## Description
Apply `ignoreDatesOrder` prop to Date Range filter.

## Screenshots

https://github.com/user-attachments/assets/af5473b5-ebe9-4d32-9ed0-89c1a8ff9b14


## Issues
[UISINVCOMP-35](https://folio-org.atlassian.net/browse/UISINVCOMP-35)

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1530