### PR TITLE
UISINVCOMP-39: Rename ui-inventory.display-settings settings scope name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@
 - [UISINVCOMP-37](https://issues.folio.org/browse/UISINVCOMP-37) Browse | Number of titles in Subject browse results does not match the number of instances returned in search.
 - [UISINVCOMP-33](https://folio-org.atlassian.net/browse/UISINVCOMP-33) If a query template is undefined - return null and don't perform a request.
 - [UISINVCOMP-36](https://issues.folio.org/browse/UISINVCOMP-36) Escape advanced search query.
+- [UISINVCOMP-39](https://issues.folio.org/browse/UISINVCOMP-39) Rename ui-inventory.display-settings settings scope name.

--- a/lib/constants/displaySettings.js
+++ b/lib/constants/displaySettings.js
@@ -1,2 +1,2 @@
 export const DISPLAY_SETTINGS_KEY = 'display-settings';
-export const DISPLAY_SETTINGS_SCOPE = 'ui-inventory.display-settings';
+export const DISPLAY_SETTINGS_SCOPE = 'ui-inventory.display-settings.manage';

--- a/lib/queries/useDisplaySettingsQuery/useDisplaySettingsQuery.test.js
+++ b/lib/queries/useDisplaySettingsQuery/useDisplaySettingsQuery.test.js
@@ -36,7 +36,7 @@ describe('useDisplaySettingsQuery', () => {
 
     expect(mockGet).toHaveBeenCalledWith('settings/entries', {
       searchParams: {
-        query: 'key=="display-settings" and scope=="ui-inventory.display-settings"',
+        query: 'key=="display-settings" and scope=="ui-inventory.display-settings.manage"',
       },
     });
 


### PR DESCRIPTION
Rename _ui-inventory.display-settings_ to _ui-inventory.display-settings.manage_
Is required by https://github.com/folio-org/ui-inventory/pull/2651

## Refs
https://folio-org.atlassian.net/browse/UISINVCOMP-39