### PR TITLE
UISINVCOMP-41: Add `qindex` to `queryKey` for `useQuery` facets to avoid getting the cached value for different search options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-inventory-components
 
+## [1.0.1] (IN PROGRESS)
+
+- [UISINVCOMP-41](https://issues.folio.org/browse/UISINVCOMP-41) Add `qindex` to `queryKey` for `useQuery` facets to avoid getting the cached value for different search options.
+
 ## [1.0.0] (https://github.com/folio-org/stripes-inventory-components/tree/v1.0.0) (2024-10-31)
 
 - [UISINVCOMP-1](https://issues.folio.org/browse/UISINVCOMP-1) Prepare the module for use.

--- a/lib/hooks/useFacets/useFacets.js
+++ b/lib/hooks/useFacets/useFacets.js
@@ -72,7 +72,6 @@ const useFacets = ({
   }, [isBrowseLookup, queryObj, data]);
 
   const { isFetching, data: facetsData } = useFacetsQuery({
-    qindex,
     searchParams,
     onSettled: () => {
       setLoadingFacetName('');
@@ -87,9 +86,10 @@ const useFacets = ({
     const newSearchParams = {
       query: buildQuery(),
       facet: facetCql,
+      qindex,
     };
 
-    const queryKey = [facetsNamespace, newSearchParams, tenantId];
+    const queryKey = [facetsNamespace, newSearchParams, tenantId, qindex];
     const queryCache = queryClient.getQueryCache().find({ queryKey });
 
     if (queryCache) {
@@ -99,7 +99,7 @@ const useFacets = ({
     } else {
       setSearchParams(newSearchParams);
     }
-  }, [facetsNamespace, queryClient, buildQuery]);
+  }, [facetsNamespace, queryClient, buildQuery, qindex]);
 
   // 1. Fetch 6 facet options when opening.
   const handleToggleAccordion = useCallback(({ id: name }) => {
@@ -133,8 +133,9 @@ const useFacets = ({
     setSearchParams({
       query: buildQuery(),
       facet: getFacetCql(name).all,
+      qindex,
     });
-  }, [buildQuery]);
+  }, [buildQuery, qindex]);
 
   // 4. Filter facet options based on the value entered into the facet input field (done in the CheckboxFacet component).
   const handleFacetOptionSearch = useCallback(({ name, value }) => {
@@ -166,8 +167,9 @@ const useFacets = ({
     setSearchParams({
       query: buildQuery(),
       facet: cqlOfOpenFacets,
+      qindex,
     });
-  }, [activeFilters, buildQuery]);
+  }, [activeFilters, buildQuery, qindex]);
 
   const getIsLoading = useCallback(name => {
     return isFetching && (loadingFacetName === name || isLoadingAllOpenFacets);

--- a/lib/hooks/useFacets/useFacets.test.js
+++ b/lib/hooks/useFacets/useFacets.test.js
@@ -902,4 +902,56 @@ describe('useFacets', () => {
       });
     });
   });
+
+  describe('when switching between Browse search options and open the same facet', () => {
+    it('should make a request with correct search params', async () => {
+      const props = {
+        initialAccordionStates: {
+          [FACETS.CONTRIBUTORS_SHARED]: false,
+          [FACETS.SUBJECTS_SHARED]: false,
+        },
+        query: {
+          ...queryObj,
+          qindex: browseModeOptions.CONTRIBUTORS,
+          sort: 'relevance',
+        },
+        filterConfig,
+        activeFilters,
+        data,
+        isBrowseLookup: true,
+      };
+
+      const { result, rerender } = renderHook(useFacets, {
+        initialProps: props,
+        wrapper: Wrapper,
+      });
+
+      act(() => result.current.onToggleAccordion({ id: FACETS.CONTRIBUTORS_SHARED }));
+      await act(async () => !result.current.isLoading);
+
+      expect(mockGet).toHaveBeenCalledWith('search/contributors/facets', {
+        searchParams: {
+          facet: `${FACETS_CQL.INSTANCES_SHARED}:6`,
+          query: '(cql.allRecords=1)',
+        },
+      });
+
+      await act(async () => {
+        rerender({
+          ...props,
+          query: {
+            ...props.query,
+            qindex: browseModeOptions.SUBJECTS,
+          },
+        });
+      });
+
+      expect(mockGet).toHaveBeenCalledWith('search/subjects/facets', {
+        searchParams: {
+          facet: `${FACETS_CQL.INSTANCES_SHARED}:6`,
+          query: '(cql.allRecords=1)',
+        },
+      });
+    });
+  });
 });

--- a/lib/hooks/useFacets/useFacetsQuery/useFacetsQuery.js
+++ b/lib/hooks/useFacets/useFacetsQuery/useFacetsQuery.js
@@ -17,12 +17,11 @@ import {
 import { processSearchErrors } from '../../../utils';
 
 const useFacetsQuery = ({
-  qindex,
   searchParams,
   onSettled,
   tenantId,
 }) => {
-  const { query, facet } = searchParams;
+  const { query, facet, qindex } = searchParams;
 
   const ky = useOkapiKy({ tenant: tenantId });
   const stripes = useStripes();


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
Browse search: counters in the `Shared` facet don't update when switching between the `Classifications (all)`, `Contributors`, and `Subjects` browse options and opening the same facet. It occurs due to data being taken from the cache since search parameters are the same for them.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->

## Approach
Add `qindex` to `queryKey` for `useQuery`. Adding `qindex` via `searchParams` state avoids double requests, since `qindex` and `searchParams` are not updated simultaneously, and also doesn't make a request on reset.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Screencasts

https://github.com/user-attachments/assets/5eb656b8-e39c-455b-9e52-b5ee3af8654a




#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
