### PR TITLE
UISINVCOMP-41: Reset `accordionsStatus` in `useFacets` for `Browse` search when `qindex` is changed (for snapshot).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.0 IN PROGRESS
 
 - [UISINVCOMP-25](https://issues.folio.org/browse/UISINVCOMP-25) *BREAKING* Replace certain facets UX with `MultiSelection` component.
+- [UISINVCOMP-41](https://issues.folio.org/browse/UISINVCOMP-41) Reset `accordionsStatus` in `useFacets` for `Browse` search when `qindex` is changed.
 
 ## [1.0.0] (https://github.com/folio-org/stripes-inventory-components/tree/v1.0.0) (2024-10-31)
 

--- a/lib/hooks/useFacets/useFacets.js
+++ b/lib/hooks/useFacets/useFacets.js
@@ -90,7 +90,7 @@ const useFacets = ({
 
   useEffect(() => {
     if (isBrowseLookup) {
-      // After changing the search parameter, it is necessary to reset the initial state of the accordions,
+      // After changing the Browse search option, it is necessary to reset the initial state of the accordions,
       // since the search parameter "facet" is formed based on these states, and if we open facets in one search option
       // and then select another search option, the search parameter "facet" will be formed taking into account the
       // facets opened in the previous search option.

--- a/lib/hooks/useFacets/useFacets.js
+++ b/lib/hooks/useFacets/useFacets.js
@@ -88,6 +88,16 @@ const useFacets = ({
     setIsLoadingAllOpenFacets(true);
   }, [activeFilters, cqlQuery]);
 
+  useEffect(() => {
+    if (isBrowseLookup) {
+      // After changing the search parameter, it is necessary to reset the initial state of the accordions,
+      // since the search parameter "facet" is formed based on these states, and if we open facets in one search option
+      // and then select another search option, the search parameter "facet" will be formed taking into account the
+      // facets opened in the previous search option.
+      setAccordionsStatus(initialAccordionStates);
+    }
+  }, [qindex]);
+
   const getIsLoading = useCallback(name => {
     return isFetching && (loadingFacetName === name || isLoadingAllOpenFacets);
   }, [isFetching, loadingFacetName, isLoadingAllOpenFacets]);

--- a/lib/hooks/useFacets/useFacets.test.js
+++ b/lib/hooks/useFacets/useFacets.test.js
@@ -721,4 +721,57 @@ describe('useFacets', () => {
       expect(mockGet).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('when switching between Browse search options and open the same facet', () => {
+    it('should make a request with correct search params', async () => {
+      const props = {
+        initialAccordionStates: {
+          [FACETS.CONTRIBUTORS_SHARED]: false,
+          [FACETS.SUBJECTS_SHARED]: false,
+        },
+        query: {
+          ...queryObj,
+          qindex: browseModeOptions.CONTRIBUTORS,
+          sort: 'relevance',
+        },
+        data,
+        isBrowseLookup: true,
+      };
+
+      const { result, rerender } = renderHook(useFacets, {
+        initialProps: props,
+        wrapper: Wrapper,
+      });
+
+      act(() => result.current.onToggleAccordion({ id: FACETS.CONTRIBUTORS_SHARED }));
+      await act(async () => !result.current.isLoading);
+
+      expect(mockGet).toHaveBeenCalledWith('search/contributors/facets', {
+        searchParams: {
+          facet: FACETS_CQL.INSTANCES_SHARED,
+          query: '(cql.allRecords=1)',
+        },
+      });
+
+      await act(async () => {
+        rerender({
+          ...props,
+          query: {
+            ...props.query,
+            qindex: browseModeOptions.SUBJECTS,
+          },
+        });
+      });
+
+      act(() => result.current.onToggleAccordion({ id: FACETS.SUBJECTS_SHARED }));
+      await act(async () => !result.current.isLoading);
+
+      expect(mockGet).toHaveBeenCalledWith('search/subjects/facets', {
+        searchParams: {
+          facet: FACETS_CQL.INSTANCES_SHARED,
+          query: '(cql.allRecords=1)',
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
Browse search: counters in the `Shared` facet don't update when switching between the `Classifications`, `Contributors`, and `Subjects` browse options and opening the same facet.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->

## Approach
Reset accordions state after `qindex` is changed.
After changing the Browse search option, it is necessary to reset the initial state of the accordions, since the search parameter "facet" is formed based on these states, and if we open facets in one search option and then select another search option, the search parameter "facet" will be formed taking into account the facets opened in the previous search option.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Issues
[UISINVCOMP-41](https://folio-org.atlassian.net/browse/UISINVCOMP-41)

## Screencasts


https://github.com/user-attachments/assets/3d93a3e4-b934-4483-8093-cb00426be6f2



#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
