### PR TITLE
UISINVCOMP-47 Apply relevance sort to find instance plugin when selected as default in Display settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UISINVCOMP-25](https://issues.folio.org/browse/UISINVCOMP-25) *BREAKING* Replace certain facets UX with `MultiSelection` component.
 - [UISINVCOMP-41](https://issues.folio.org/browse/UISINVCOMP-41) Reset `accordionsStatus` in `useFacets` for `Browse` search when `qindex` is changed.
+- [UISINVCOMP-47](https://issues.folio.org/browse/UISINVCOMP-47) Apply relevance sort to find instance plugin when selected as default in Display settings.
 
 ## [1.0.1] (https://github.com/folio-org/stripes-inventory-components/tree/v1.0.1) (2024-12-02)
 

--- a/lib/buildSearchQuery/buildSearchQuery.js
+++ b/lib/buildSearchQuery/buildSearchQuery.js
@@ -46,11 +46,12 @@ export const buildSearchQuery = (applyDefaultFilters) => (queryParams, pathCompo
 
   if (queryIndex === queryIndexes.QUERY_SEARCH && queryValue.match('sortby')) {
     query.sort = '';
-  } else if (query.sort && query.sort === 'relevance') {
-    query.sort = '';
   } else if (!query.sort) {
-    // Default sort for filtering/searching instances/holdings/items should be by title (UIIN-1046)
-    query.sort = DEFAULT_SORT;
+    query.sort = props.contextData?.displaySettings?.defaultSort || DEFAULT_SORT;
+  }
+
+  if (query.sort === 'relevance') {
+    query.sort = '';
   }
 
   applyDefaultFilters(query, props.stripes, props.isSharedDefaultFilter);

--- a/lib/buildSearchQuery/buildSearchQuery.test.js
+++ b/lib/buildSearchQuery/buildSearchQuery.test.js
@@ -296,4 +296,40 @@ describe('buildSearchQuery', () => {
 
     expect(mockReplaceRequestUrlQuery).toHaveBeenCalledWith(cql);
   });
+
+  describe('when displaySettings has a default sort', () => {
+    it('should apply the sort to requests', () => {
+      const qindex = queryIndexes.CALL_NUMBER;
+      const queryParams = { ...defaultQueryParamsMap[qindex] };
+      const props = {
+        ...defaultProps,
+        contextData: {
+          displaySettings: {
+            defaultSort: 'title',
+          },
+        },
+      };
+      const cql = buildSearchQuery(noop)(...getBuildQueryArgs({ queryParams, props }));
+
+      expect(cql).toEqual(expect.stringContaining('sortby title'));
+    });
+
+    describe('when default sort is relevance', () => {
+      it('should clear the sort', () => {
+        const qindex = queryIndexes.CALL_NUMBER;
+        const queryParams = { ...defaultQueryParamsMap[qindex] };
+        const props = {
+          ...defaultProps,
+          contextData: {
+            displaySettings: {
+              defaultSort: 'relevance',
+            },
+          },
+        };
+        const cql = buildSearchQuery(noop)(...getBuildQueryArgs({ queryParams, props }));
+
+        expect(cql).toEqual('itemEffectiveShelvingOrder==/string "Some call number query"');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description
Apply the default sort settings in `buildSearchQuery` util.

## Screenshots

https://github.com/user-attachments/assets/c803efac-d8c6-48ff-a69f-38fa6da141cd



## Issues
[UISINVCOMP-47](https://folio-org.atlassian.net/browse/UISINVCOMP-47)