### PR TITLE
UISINVCOMP-43: Reset the state of records on unmount (follow-up PR).

### DIFF
--- a/lib/hocs/withSearchErrors/withSearchErrors.js
+++ b/lib/hocs/withSearchErrors/withSearchErrors.js
@@ -29,6 +29,14 @@ const withSearchErrors = (WrappedComponent) => {
     const requestUrlQuery = props.resources.requestUrlQuery;
 
     useEffect(() => {
+      return () => {
+        // reset the state of records on unmount to avoid an error from a previous request what will trigger
+        // the toast notification again when the component is remounted.
+        props.mutator?.records?.reset();
+      };
+    }, []);
+
+    useEffect(() => {
       if (error) {
         const params = {
           ...manifestParams,
@@ -53,6 +61,11 @@ const withSearchErrors = (WrappedComponent) => {
   SearchErrors.manifest = WrappedComponent.manifest;
   SearchErrors.propTypes = {
     resources: PropTypes.object.isRequired,
+    mutator: PropTypes.shape({
+      records: PropTypes.shape({
+        reset: PropTypes.func.isRequired,
+      }),
+    }).isRequired,
   };
 
   return SearchErrors;

--- a/lib/hocs/withSearchErrors/withSearchErrors.test.js
+++ b/lib/hocs/withSearchErrors/withSearchErrors.test.js
@@ -27,6 +27,11 @@ const resources = {
     failed: false,
   },
 };
+const mutator = {
+  records: {
+    reset: jest.fn(),
+  },
+};
 
 const getComponent = (props = {}, { showToast } = {}) => (
   <Harness
@@ -35,6 +40,7 @@ const getComponent = (props = {}, { showToast } = {}) => (
   >
     <SearchErrors
       resources={resources}
+      mutator={mutator}
       {...props}
     />
     {showToast && (
@@ -122,10 +128,10 @@ describe('withSearchErrors', () => {
     };
     const { rerender } = renderSearchErrors(props);
 
-    expect(mockWrappedComponent).toHaveBeenLastCalledWith({
+    expect(mockWrappedComponent).toHaveBeenLastCalledWith(expect.objectContaining({
       ...props,
       isRequestUrlExceededLimit: true,
-    }, {});
+    }), {});
 
     const props2 = {
       resources: {
@@ -137,10 +143,10 @@ describe('withSearchErrors', () => {
 
     rerender(getComponent(props2));
 
-    expect(mockWrappedComponent).toHaveBeenLastCalledWith({
+    expect(mockWrappedComponent).toHaveBeenLastCalledWith(expect.objectContaining({
       ...props2,
       isRequestUrlExceededLimit: false,
-    }, {});
+    }), {});
   });
 
   it('should display the default error for other errors', () => {
@@ -157,14 +163,25 @@ describe('withSearchErrors', () => {
 
     renderSearchErrors(props);
 
-    expect(mockWrappedComponent).toHaveBeenLastCalledWith({
+    expect(mockWrappedComponent).toHaveBeenLastCalledWith(expect.objectContaining({
       ...props,
       isRequestUrlExceededLimit: false,
-    }, {});
+    }), {});
 
     expect(mockSendCallout).toHaveBeenCalledWith({
       message: 'Search could not be processed. Please check your query and try again.',
       type: 'error',
+    });
+  });
+
+  describe('when unmounting', () => {
+    it('should reset the state of records to avoid showing the error message from the previous request', () => {
+      const { unmount } = renderSearchErrors();
+
+      unmount();
+
+      expect(mockWrappedComponent.manifest.records.accumulate).toBe('true');
+      expect(mutator.records.reset).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
When we get an error while searching and then close the find-instance plugin, and reopen it, it will show again the same toast notification error. It is occurring, because Redux keeps the error, it doesn't reset it on unmount.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->

## Approach
Reset the `records` state on unmount.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Issues
[UISINVCOMP-43 - Comment about the issue](https://folio-org.atlassian.net/browse/UISINVCOMP-43?focusedCommentId=247109)

## Screencasts

https://github.com/user-attachments/assets/ecd40ac7-c5b3-4330-b5f6-eb77056ffbbb



#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
