### PR TITLE
UISINVCOMP-63 handle duplicate locations coming from different tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-inventory-components
 
+## [2.1.0] (IN PROGRESS)
+
+- [UISINVCOMP-63](https://issues.folio.org/browse/UISINVCOMP-63) Display correct Effective location when it exists on multiple tenants.
+
 ## [2.0.1] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.1) (2025-04-09)
 
 - [UISINVCOMP-59](https://issues.folio.org/browse/UISINVCOMP-59) Remove "Shelving order" from search option and advanced search on Instance tab.

--- a/lib/hooks/useFacets/useFacetOptions/useFacetOptions.js
+++ b/lib/hooks/useFacets/useFacetOptions/useFacetOptions.js
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
+import { useStripes } from '@folio/stripes/core';
+
 import {
   browseModeOptions,
   FACETS,
@@ -15,9 +17,13 @@ import {
   getStatisticalCodeOptions,
   getSuppressedOptions
 } from './utils';
+import { isConsortiaEnv } from '../../../utils';
 
 const useFacetOptions = ({ activeFilters, qindex, isBrowseLookup, data, facetsData }) => {
+  const stripes = useStripes();
   const intl = useIntl();
+
+  const { tenant: tenantId } = stripes.okapi;
 
   const optionsMap = useMemo(() => {
     return {
@@ -50,8 +56,8 @@ const useFacetOptions = ({ activeFilters, qindex, isBrowseLookup, data, facetsDa
         const name = heldByFacetMap[qindex];
         return getFacetOptions(activeFilters[name], values, data.consortiaTenants);
       },
-      [FACETS_CQL.EFFECTIVE_LOCATION]: (values) => getFacetOptions(activeFilters[FACETS.EFFECTIVE_LOCATION], values, data.locations),
-      [FACETS_CQL.CALL_NUMBERS_EFFECTIVE_LOCATION]: (values) => getFacetOptions(activeFilters[FACETS.CALL_NUMBERS_EFFECTIVE_LOCATION], values, data.locations),
+      [FACETS_CQL.EFFECTIVE_LOCATION]: (values) => getFacetOptions(activeFilters[FACETS.EFFECTIVE_LOCATION], values, data.locations, { tenantId: isConsortiaEnv(stripes) ? tenantId : null }),
+      [FACETS_CQL.CALL_NUMBERS_EFFECTIVE_LOCATION]: (values) => getFacetOptions(activeFilters[FACETS.CALL_NUMBERS_EFFECTIVE_LOCATION], values, data.locations, { tenantId: isConsortiaEnv(stripes) ? tenantId : null }),
       [FACETS_CQL.LANGUAGES]: (values) => getLanguageOptions(activeFilters[FACETS.LANGUAGE], intl, values),
       [FACETS_CQL.INSTANCE_TYPE]: (values) => getFacetOptions(activeFilters[FACETS.RESOURCE], values, data.instanceTypes),
       [FACETS_CQL.INSTANCE_FORMAT]: (values) => getFacetOptions(activeFilters[FACETS.FORMAT], values, data.instanceFormats),

--- a/lib/hooks/useFacets/useFacetOptions/utils.js
+++ b/lib/hooks/useFacets/useFacetOptions/utils.js
@@ -9,6 +9,7 @@ const getFacetDataMap = (facetData, key = 'id') => {
 
   facetData.forEach(data => {
     const id = data[key];
+
     facetDataMap.set(id, data);
   });
 
@@ -52,7 +53,7 @@ const getSelectedFacetOptionsWithoutCount = (selectedFiltersId, entries, facetDa
   return selectedFiltersWithoutCount;
 };
 
-export const getFacetOptions = (selectedFiltersId, values, facetData, key, parse = parseOption) => {
+export const getFacetOptions = (selectedFiltersId, values, facetData, { tenantId, key = 'id', parse = parseOption } = {}) => {
   if (!facetData) return null;
 
   const facetDataMap = getFacetDataMap(facetData, key);
@@ -60,11 +61,17 @@ export const getFacetOptions = (selectedFiltersId, values, facetData, key, parse
   const restFilters = values.reduce((accum, entry) => {
     if (!entry.totalRecords) return accum;
 
-    const facet = facetDataMap.get(entry.id);
+    let facets = facetData.filter(data => data[key] === entry.id);
 
-    if (facet) {
-      const option = parse(facetDataMap.get(entry.id), entry.totalRecords);
-      accum.push(option);
+    if (tenantId) {
+      facets = facets.filter(data => data.tenantId === tenantId);
+    }
+
+    if (facets.length) {
+      facets.forEach(facet => {
+        const option = parse(facet, entry.totalRecords);
+        accum.push(option);
+      });
     } else {
       accum.push({
         id: entry.id,
@@ -254,7 +261,7 @@ export const getStatisticalCodeOptions = (selectedFiltersId, values, statistical
     return option;
   };
 
-  return getFacetOptions(selectedFiltersId, values, statisticalCodes, 'id', parseStatisticalCodeOption);
+  return getFacetOptions(selectedFiltersId, values, statisticalCodes, { key: 'id', parse: parseStatisticalCodeOption });
 };
 
 const getSelectedLangsWithoutCount = (selectedLanguagesId, intl, langs) => {

--- a/lib/hooks/useFacets/useFacetOptions/utils.test.js
+++ b/lib/hooks/useFacets/useFacetOptions/utils.test.js
@@ -24,7 +24,7 @@ describe('getFacetOptions', () => {
       { label: 'Filter 3', value: 'filter3', count: 4 },
       { label: 'Filter 2', value: 'filter2', count: 0 },
     ];
-    expect(getFacetOptions(selectedFiltersId, entries, facetData, key)).toEqual(expectedOptions);
+    expect(getFacetOptions(selectedFiltersId, entries, facetData, { key })).toEqual(expectedOptions);
   });
   it('getFacetOptions handles invalid id values in entries correctly', () => {
     const selectedFiltersId = ['filter1', 'filter2'];
@@ -43,7 +43,7 @@ describe('getFacetOptions', () => {
       { id: 'invalid', isDeleted: true },
       { label: 'Filter 2', value: 'filter2', count: 0 },
     ];
-    expect(getFacetOptions(selectedFiltersId, entries, facetData, key)).toEqual(expectedOptions);
+    expect(getFacetOptions(selectedFiltersId, entries, facetData, { key })).toEqual(expectedOptions);
   });
 });
 

--- a/lib/hooks/useFacets/useFacets.test.js
+++ b/lib/hooks/useFacets/useFacets.test.js
@@ -850,22 +850,6 @@ describe('useFacets', () => {
         });
       });
 
-      expect(mockGet).toHaveBeenLastCalledWith('search/instances/facets', {
-        searchParams: {
-          facet: 'items.effectiveLocationId',
-          query: 'staffSuppress=="false"',
-        },
-      });
-      expect(result.current.activeFilters).toEqual({
-        staffSuppress: ['false'],
-      });
-      expect(result.current.accordionsStatus).toEqual({
-        effectiveLocation: true,
-        tenantId: false,
-        shared: false,
-        staffSuppress: false,
-        language: false,
-      });
       expect(result.current.facetOptions).toEqual({
         'instances.locationId': [
           { count: 14, label: 'Annex (college)', value: 'id-1' },

--- a/lib/hooks/useFacets/useFacets.test.js
+++ b/lib/hooks/useFacets/useFacets.test.js
@@ -1,5 +1,8 @@
 import { renderHook, act } from '@folio/jest-config-stripes/testing-library/react';
-import { useOkapiKy } from '@folio/stripes/core';
+import {
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
 
 import { useFacets } from './useFacets';
 import Harness from '../../../test/jest/helpers/Harness';
@@ -12,6 +15,7 @@ import {
   queryIndexes,
   segments,
 } from '../../constants';
+import buildStripes from '../../../test/jest/__mock__/stripesCore.mock';
 
 const initialAccordionStates = {
   effectiveLocation: false,
@@ -93,6 +97,10 @@ describe('useFacets', () => {
     jest.clearAllMocks();
     useOkapiKy.mockReturnValue({
       get: mockGet,
+    });
+    useStripes.mockReturnValue({
+      ...buildStripes(),
+      hasInterface: jest.fn().mockReturnValue(false),
     });
   });
 
@@ -771,6 +779,98 @@ describe('useFacets', () => {
           facet: FACETS_CQL.INSTANCES_SHARED,
           query: '(cql.allRecords=1)',
         },
+      });
+    });
+  });
+
+  describe('when on an ECS environment', () => {
+    const locationsFromAllTenants = [
+      {
+        id: 'id-1',
+        name: 'Annex (consortium)',
+        tenantId: 'consortium'
+      },
+      {
+        id: 'id-2',
+        name: 'Main Library (consortium)',
+        tenantId: 'consortium'
+      },
+      {
+        id: 'id-1',
+        name: 'Annex (college)',
+        tenantId: 'college'
+      },
+      {
+        id: 'id-2',
+        name: 'Main Library (college)',
+        tenantId: 'college'
+      },
+    ];
+
+    beforeEach(() => {
+      useStripes.mockReturnValue({
+        ...buildStripes(),
+        hasInterface: jest.fn().mockReturnValue(true),
+        okapi: {
+          tenant: 'college',
+        },
+      });
+    });
+
+    it('should display effective location values from current tenant', async () => {
+      json.mockResolvedValue({ facets: effectiveLocationResponse });
+
+      const props = {
+        initialAccordionStates,
+        query: {
+          ...queryObj,
+          filters: 'staffSuppress.false',
+        },
+        data: {
+          ...data,
+          locations: locationsFromAllTenants,
+        },
+      };
+
+      const { result, rerender } = renderHook(useFacets, {
+        initialProps: props,
+        wrapper: Wrapper,
+      });
+
+      await act(async () => result.current.onToggleAccordion({ id: 'effectiveLocation' }));
+      await act(async () => !result.current.isLoading);
+
+      await act(async () => {
+        rerender({
+          ...props,
+          query: {
+            ...queryObj,
+            filters: 'staffSuppress.false',
+          },
+        });
+      });
+
+      expect(mockGet).toHaveBeenLastCalledWith('search/instances/facets', {
+        searchParams: {
+          facet: 'items.effectiveLocationId',
+          query: 'staffSuppress=="false"',
+        },
+      });
+      expect(result.current.activeFilters).toEqual({
+        staffSuppress: ['false'],
+      });
+      expect(result.current.accordionsStatus).toEqual({
+        effectiveLocation: true,
+        tenantId: false,
+        shared: false,
+        staffSuppress: false,
+        language: false,
+      });
+      expect(result.current.facetOptions).toEqual({
+        'instances.locationId': [
+          { count: 14, label: 'Annex (college)', value: 'id-1' },
+          { count: 4, label: 'Main Library (college)', value: 'id-2' },
+        ],
       });
     });
   });

--- a/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.js
+++ b/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.js
@@ -23,7 +23,7 @@ const useLocationsFromAllTenantsQuery = ({ consortiaTenants = [], tenantId }) =>
   });
 
   const locationsFromAllTenants = useMemo(() => {
-    const locationsOfAllTenants = consolidatedLocations?.locations;
+    const locationsOfAllTenants = consolidatedLocations?.locations || [];
 
     const locationCounts = locationsOfAllTenants?.reduce((acc, location) => {
       acc[location.name] = (acc[location.name] ?? 0) + 1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-inventory-components",
-  "version": "2.1.0",
+  "version": "2.0.2",
   "description": "",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-inventory-components",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description
Fix an issue on ECS environments where when searching local records Effective location facet showed locations from a different tenant.
This was caused by multiple locations with same id, but different tenantId coming in a response for locations from all tenants. Discussed it with BE and it is currently expected as there are no limitations on duplicate location ids across all tenants, so we need to fix it on UI side.

On the UI we previously took an array of locations and turned it into a map, but since there are duplicate ids some locationd would be overwritten by the last found location by that id. Whatever the last location with that id was in the response - that's what was shown in the facet option.

The fix is to not use a map, but instead filter all locations by id, and if filter options can come from different tenants (for now it's just Effective location) then also pass `tenantId` so we can choose the location that comes fromthe current user's tenant.

## Screenshots

https://github.com/user-attachments/assets/7b465403-d110-4d00-a57e-e72eea800fab



## Issues
[UISINVCOMP-63](https://folio-org.atlassian.net/browse/UISINVCOMP-63)