### PR TITLE
UISINVCOMP-40 "startsWith" search by keyword and title should also search for a title that starts with a quotation mark.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-inventory-components
 
+## [2.1.0] (IN PROGRESS)
+
+- [UISINVCOMP-40](https://issues.folio.org/browse/UISINVCOMP-40) "startsWith" search by keyword and title should also search for a title that starts with a quotation mark.
+
 ## [2.0.3] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.3) (2025-04-18)
 
 - [UISINVCOMP-63](https://issues.folio.org/browse/UISINVCOMP-63) Display correct Effective location when it exists on multiple tenants.

--- a/lib/constants/fieldSearchConfigurations.js
+++ b/lib/constants/fieldSearchConfigurations.js
@@ -2,7 +2,7 @@ export const fieldSearchConfigurations = {
   keyword: {
     exactPhrase: 'keyword=="%{query.query}"',
     containsAll: 'keyword all "%{query.query}"',
-    startsWith: 'keyword all "%{query.query}*"',
+    startsWith: 'keyword all "%{query.query}*" or keyword all "\\"%{query.query}*"',
     containsAny: 'keyword any "%{query.query}"',
   },
   contributor: {
@@ -14,7 +14,7 @@ export const fieldSearchConfigurations = {
   title: {
     exactPhrase: 'title=="%{query.query}"',
     containsAll: 'title all "%{query.query}"',
-    startsWith: 'title all "%{query.query}*"',
+    startsWith: 'title all "%{query.query}*" or title all "\\"%{query.query}*"',
     containsAny: 'title any "%{query.query}"',
   },
   isbn: {

--- a/lib/hooks/useFacets/useFacets.test.js
+++ b/lib/hooks/useFacets/useFacets.test.js
@@ -559,7 +559,7 @@ describe('useFacets', () => {
       expect(mockGet).toHaveBeenCalledWith('search/instances/facets', {
         searchParams: {
           facet: FACETS_CQL.SHARED,
-          query: 'isbn="*test1*" or title=="test2" or keyword all "test3*"',
+          query: 'isbn="*test1*" or title=="test2" or keyword all "test3*" or keyword all "\\"test3*"',
         },
       });
     });

--- a/lib/utils/utils.test.js
+++ b/lib/utils/utils.test.js
@@ -63,7 +63,23 @@ describe('utils', () => {
     it('should escape quotes', () => {
       const query = getAdvancedSearchTemplate('title startsWith "Seeing-Eye"');
 
-      expect(query).toBe('title all "\\"Seeing-Eye\\"*"');
+      expect(query).toBe('title all "\\"Seeing-Eye\\"*" or title all "\\"\\"Seeing-Eye\\"*"');
+    });
+
+    describe('when searching by title', () => {
+      it('should also add a quote at the beginning', () => {
+        const query = getAdvancedSearchTemplate('title startsWith Seeing-Eye"');
+
+        expect(query).toBe('title all "Seeing-Eye\\"*" or title all "\\"Seeing-Eye\\"*"');
+      });
+    });
+
+    describe('when searching by keyword', () => {
+      it('should also add a quote at the beginning', () => {
+        const query = getAdvancedSearchTemplate('keyword startsWith Seeing-Eye"');
+
+        expect(query).toBe('keyword all "Seeing-Eye\\"*" or keyword all "\\"Seeing-Eye\\"*"');
+      });
     });
   });
 });


### PR DESCRIPTION
## Description
Users should be able to find Instance records with titles that start with quotations marks without entering the opening quotation mark in the search box. This only applies to `startsWih` keyword and title searches.
The solution is to duplicate the search condition: one with a starting quotation mark, and one without it, and join them with an `or` condition.

## Screenshots

https://github.com/user-attachments/assets/51642ef8-ba61-4f5b-84ad-e7cbabdb6224


## Issues
[UISINVCOMP-40](https://folio-org.atlassian.net/browse/UISINVCOMP-40)