### PR TITLE
UISINVCOMP-68 Hide tenant names next to locations with duplicate ids across tenants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.1.0] (IN PROGRESS)
 
 - [UISINVCOMP-40](https://issues.folio.org/browse/UISINVCOMP-40) "startsWith" search by keyword and title should also search for a title that starts with a quotation mark.
+- [UISINVCOMP-68](https://issues.folio.org/browse/UISINVCOMP-68) Hide tenant names next to locations with duplicate ids across tenants.
 
 ## [2.0.3] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.3) (2025-04-18)
 

--- a/lib/hooks/useFacets/useFacetOptions/useFacetOptions.js
+++ b/lib/hooks/useFacets/useFacetOptions/useFacetOptions.js
@@ -1,8 +1,6 @@
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
-import { useStripes } from '@folio/stripes/core';
-
 import {
   browseModeOptions,
   FACETS,
@@ -17,13 +15,9 @@ import {
   getStatisticalCodeOptions,
   getSuppressedOptions
 } from './utils';
-import { isConsortiaEnv } from '../../../utils';
 
 const useFacetOptions = ({ activeFilters, qindex, isBrowseLookup, data, facetsData }) => {
-  const stripes = useStripes();
   const intl = useIntl();
-
-  const { tenant: tenantId } = stripes.okapi;
 
   const optionsMap = useMemo(() => {
     return {
@@ -56,8 +50,8 @@ const useFacetOptions = ({ activeFilters, qindex, isBrowseLookup, data, facetsDa
         const name = heldByFacetMap[qindex];
         return getFacetOptions(activeFilters[name], values, data.consortiaTenants);
       },
-      [FACETS_CQL.EFFECTIVE_LOCATION]: (values) => getFacetOptions(activeFilters[FACETS.EFFECTIVE_LOCATION], values, data.locations, { tenantId: isConsortiaEnv(stripes) ? tenantId : null }),
-      [FACETS_CQL.CALL_NUMBERS_EFFECTIVE_LOCATION]: (values) => getFacetOptions(activeFilters[FACETS.CALL_NUMBERS_EFFECTIVE_LOCATION], values, data.locations, { tenantId: isConsortiaEnv(stripes) ? tenantId : null }),
+      [FACETS_CQL.EFFECTIVE_LOCATION]: (values) => getFacetOptions(activeFilters[FACETS.EFFECTIVE_LOCATION], values, data.locations),
+      [FACETS_CQL.CALL_NUMBERS_EFFECTIVE_LOCATION]: (values) => getFacetOptions(activeFilters[FACETS.CALL_NUMBERS_EFFECTIVE_LOCATION], values, data.locations),
       [FACETS_CQL.LANGUAGES]: (values) => getLanguageOptions(activeFilters[FACETS.LANGUAGE], intl, values),
       [FACETS_CQL.INSTANCE_TYPE]: (values) => getFacetOptions(activeFilters[FACETS.RESOURCE], values, data.instanceTypes),
       [FACETS_CQL.INSTANCE_FORMAT]: (values) => getFacetOptions(activeFilters[FACETS.FORMAT], values, data.instanceFormats),

--- a/lib/hooks/useFacets/useFacetOptions/utils.js
+++ b/lib/hooks/useFacets/useFacetOptions/utils.js
@@ -9,7 +9,6 @@ const getFacetDataMap = (facetData, key = 'id') => {
 
   facetData.forEach(data => {
     const id = data[key];
-
     facetDataMap.set(id, data);
   });
 
@@ -53,7 +52,7 @@ const getSelectedFacetOptionsWithoutCount = (selectedFiltersId, entries, facetDa
   return selectedFiltersWithoutCount;
 };
 
-export const getFacetOptions = (selectedFiltersId, values, facetData, { tenantId, key = 'id', parse = parseOption } = {}) => {
+export const getFacetOptions = (selectedFiltersId, values, facetData, key, parse = parseOption) => {
   if (!facetData) return null;
 
   const facetDataMap = getFacetDataMap(facetData, key);
@@ -61,17 +60,11 @@ export const getFacetOptions = (selectedFiltersId, values, facetData, { tenantId
   const restFilters = values.reduce((accum, entry) => {
     if (!entry.totalRecords) return accum;
 
-    let facets = facetData.filter(data => data[key] === entry.id);
+    const facet = facetDataMap.get(entry.id);
 
-    if (tenantId) {
-      facets = facets.filter(data => data.tenantId === tenantId);
-    }
-
-    if (facets.length) {
-      facets.forEach(facet => {
-        const option = parse(facet, entry.totalRecords);
-        accum.push(option);
-      });
+    if (facet) {
+      const option = parse(facetDataMap.get(entry.id), entry.totalRecords);
+      accum.push(option);
     } else {
       accum.push({
         id: entry.id,
@@ -261,7 +254,7 @@ export const getStatisticalCodeOptions = (selectedFiltersId, values, statistical
     return option;
   };
 
-  return getFacetOptions(selectedFiltersId, values, statisticalCodes, { key: 'id', parse: parseStatisticalCodeOption });
+  return getFacetOptions(selectedFiltersId, values, statisticalCodes, 'id', parseStatisticalCodeOption);
 };
 
 const getSelectedLangsWithoutCount = (selectedLanguagesId, intl, langs) => {

--- a/lib/hooks/useFacets/useFacetOptions/utils.test.js
+++ b/lib/hooks/useFacets/useFacetOptions/utils.test.js
@@ -24,7 +24,7 @@ describe('getFacetOptions', () => {
       { label: 'Filter 3', value: 'filter3', count: 4 },
       { label: 'Filter 2', value: 'filter2', count: 0 },
     ];
-    expect(getFacetOptions(selectedFiltersId, entries, facetData, { key })).toEqual(expectedOptions);
+    expect(getFacetOptions(selectedFiltersId, entries, facetData, key)).toEqual(expectedOptions);
   });
   it('getFacetOptions handles invalid id values in entries correctly', () => {
     const selectedFiltersId = ['filter1', 'filter2'];
@@ -43,7 +43,7 @@ describe('getFacetOptions', () => {
       { id: 'invalid', isDeleted: true },
       { label: 'Filter 2', value: 'filter2', count: 0 },
     ];
-    expect(getFacetOptions(selectedFiltersId, entries, facetData, { key })).toEqual(expectedOptions);
+    expect(getFacetOptions(selectedFiltersId, entries, facetData, key)).toEqual(expectedOptions);
   });
 });
 

--- a/lib/hooks/useFacets/useFacets.test.js
+++ b/lib/hooks/useFacets/useFacets.test.js
@@ -1,8 +1,5 @@
 import { renderHook, act } from '@folio/jest-config-stripes/testing-library/react';
-import {
-  useOkapiKy,
-  useStripes,
-} from '@folio/stripes/core';
+import { useOkapiKy } from '@folio/stripes/core';
 
 import { useFacets } from './useFacets';
 import Harness from '../../../test/jest/helpers/Harness';
@@ -15,7 +12,6 @@ import {
   queryIndexes,
   segments,
 } from '../../constants';
-import buildStripes from '../../../test/jest/__mock__/stripesCore.mock';
 
 const initialAccordionStates = {
   effectiveLocation: false,
@@ -97,10 +93,6 @@ describe('useFacets', () => {
     jest.clearAllMocks();
     useOkapiKy.mockReturnValue({
       get: mockGet,
-    });
-    useStripes.mockReturnValue({
-      ...buildStripes(),
-      hasInterface: jest.fn().mockReturnValue(false),
     });
   });
 
@@ -779,82 +771,6 @@ describe('useFacets', () => {
           facet: FACETS_CQL.INSTANCES_SHARED,
           query: '(cql.allRecords=1)',
         },
-      });
-    });
-  });
-
-  describe('when on an ECS environment', () => {
-    const locationsFromAllTenants = [
-      {
-        id: 'id-1',
-        name: 'Annex (consortium)',
-        tenantId: 'consortium'
-      },
-      {
-        id: 'id-2',
-        name: 'Main Library (consortium)',
-        tenantId: 'consortium'
-      },
-      {
-        id: 'id-1',
-        name: 'Annex (college)',
-        tenantId: 'college'
-      },
-      {
-        id: 'id-2',
-        name: 'Main Library (college)',
-        tenantId: 'college'
-      },
-    ];
-
-    beforeEach(() => {
-      useStripes.mockReturnValue({
-        ...buildStripes(),
-        hasInterface: jest.fn().mockReturnValue(true),
-        okapi: {
-          tenant: 'college',
-        },
-      });
-    });
-
-    it('should display effective location values from current tenant', async () => {
-      json.mockResolvedValue({ facets: effectiveLocationResponse });
-
-      const props = {
-        initialAccordionStates,
-        query: {
-          ...queryObj,
-          filters: 'staffSuppress.false',
-        },
-        data: {
-          ...data,
-          locations: locationsFromAllTenants,
-        },
-      };
-
-      const { result, rerender } = renderHook(useFacets, {
-        initialProps: props,
-        wrapper: Wrapper,
-      });
-
-      await act(async () => result.current.onToggleAccordion({ id: 'effectiveLocation' }));
-      await act(async () => !result.current.isLoading);
-
-      await act(async () => {
-        rerender({
-          ...props,
-          query: {
-            ...queryObj,
-            filters: 'staffSuppress.false',
-          },
-        });
-      });
-
-      expect(result.current.facetOptions).toEqual({
-        'instances.locationId': [
-          { count: 14, label: 'Annex (college)', value: 'id-1' },
-          { count: 4, label: 'Main Library (college)', value: 'id-2' },
-        ],
       });
     });
   });

--- a/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.js
+++ b/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.js
@@ -23,7 +23,7 @@ const useLocationsFromAllTenantsQuery = ({ consortiaTenants = [], tenantId }) =>
   });
 
   const locationsFromAllTenants = useMemo(() => {
-    const locationsOfAllTenants = consolidatedLocations?.locations || [];
+    const locationsOfAllTenants = consolidatedLocations?.locations;
 
     const locationCounts = locationsOfAllTenants?.reduce((acc, location) => {
       acc[location.name] = (acc[location.name] ?? 0) + 1;

--- a/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.js
+++ b/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.js
@@ -32,7 +32,12 @@ const useLocationsFromAllTenantsQuery = ({ consortiaTenants = [], tenantId }) =>
 
     // The tenant's name is added in brackets for locations with the same name.
     const locationsWithTenantNameForDuplicates = locationsOfAllTenants?.map(location => {
-      if (locationCounts[location.name] > 1) {
+      const isLocationIdDuplicate = locationsOfAllTenants.filter(_location => _location.id === location.id).length > 1;
+
+      // don't add tenant name to locations which have duplicate ids across tenants
+      // in future BE will make changes to make sure this doesn't happen, but for now
+      // we'll just have to do this
+      if (locationCounts[location.name] > 1 && !isLocationIdDuplicate) {
         const tenantName = consortiaTenants.find(tenant => tenant.id === location.tenantId)?.name;
 
         return {

--- a/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.test.js
+++ b/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.test.js
@@ -40,13 +40,14 @@ describe('useLocationsFromAllTenantsQuery', () => {
         locations: [
           { id: 'location-id-1', name: 'name-1', tenantId: 'tenant-id-1' },
           { id: 'location-id-2', name: 'name-2', tenantId: 'tenant-id-2' },
-          { id: 'location-id-3', name: 'name-1', tenantId: 'tenant-id-3' },
+          { id: 'location-id-1', name: 'name-1', tenantId: 'tenant-id-3' },
+          { id: 'location-id-3', name: 'name-2', tenantId: 'tenant-id-3' },
         ],
       }),
     });
 
     describe('when location name is not unique', () => {
-      it('should display tenant`s name in parentheses next to the location name', async () => {
+      it('should display tenant`s name in parentheses next to the location name that don`t have duplicate ids', async () => {
         useOkapiKy.mockClear().mockReturnValue({
           get: mockGet,
         });
@@ -56,9 +57,10 @@ describe('useLocationsFromAllTenantsQuery', () => {
         await act(() => !result.current.isLoading);
 
         expect(result.current.locationsFromAllTenants).toEqual([
-          { id: 'location-id-1', name: 'name-1 (College)', tenantId: 'tenant-id-1' },
-          { id: 'location-id-2', name: 'name-2', tenantId: 'tenant-id-2' },
-          { id: 'location-id-3', name: 'name-1 (School)', tenantId: 'tenant-id-3' },
+          { id: 'location-id-1', name: 'name-1', tenantId: 'tenant-id-1' },
+          { id: 'location-id-2', name: 'name-2 (Professional)', tenantId: 'tenant-id-2' },
+          { id: 'location-id-1', name: 'name-1', tenantId: 'tenant-id-3' },
+          { id: 'location-id-3', name: 'name-2 (School)', tenantId: 'tenant-id-3' },
         ]);
       });
     });
@@ -71,9 +73,10 @@ describe('useLocationsFromAllTenantsQuery', () => {
       expect(mockGet).toHaveBeenCalledWith('search/consortium/locations');
 
       expect(result.current.locationsFromAllTenants).toEqual([
-        { id: 'location-id-1', name: 'name-1 (College)', tenantId: 'tenant-id-1' },
-        { id: 'location-id-2', name: 'name-2', tenantId: 'tenant-id-2' },
-        { id: 'location-id-3', name: 'name-1 (School)', tenantId: 'tenant-id-3' },
+        { id: 'location-id-1', name: 'name-1', tenantId: 'tenant-id-1' },
+        { id: 'location-id-2', name: 'name-2 (Professional)', tenantId: 'tenant-id-2' },
+        { id: 'location-id-1', name: 'name-1', tenantId: 'tenant-id-3' },
+        { id: 'location-id-3', name: 'name-2 (School)', tenantId: 'tenant-id-3' },
       ]);
     });
   });


### PR DESCRIPTION
## Description
In https://github.com/folio-org/stripes-inventory-components/pull/123 to handle locations having duplicate ids across tenants we showed only locations from a current tenant, but it's not working for a central tenant context.
So we decided to revert those changes, and simply not show tenant names next to locations with duplicate ids. This will work the same for member and central tenants.

## Screenshots

https://github.com/user-attachments/assets/6cd1ad99-21af-4755-83d1-3a77da3985dd


## Issues
[UISINVCOMP-68](https://folio-org.atlassian.net/browse/UISINVCOMP-68)