### PR TITLE
UISINVCOMP-70 Change title of Keyword search option of "Advanced search" to remove identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.1.0] (IN PROGRESS)
 
 - [UISINVCOMP-40](https://issues.folio.org/browse/UISINVCOMP-40) "startsWith" search by keyword and title should also search for a title that starts with a quotation mark.
+- [UISINVCOMP-70](https://issues.folio.org/browse/UISINVCOMP-70) Change title of Keyword search option of "Advanced search" to remove identifiers.
 
 ## [2.0.4] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.4) (2025-05-13)
 

--- a/lib/filterConfig.js
+++ b/lib/filterConfig.js
@@ -113,7 +113,7 @@ export const filterConfigMap = {
 
 export const advancedSearchIndexes = {
   [segments.instances]: [
-    { label: 'stripes-inventory-components.search.keyword', value: 'keyword' },
+    { label: 'stripes-inventory-components.search.advanced.keyword', value: 'keyword' },
     { label: 'stripes-inventory-components.search.contributor', value: 'contributor' },
     { label: 'stripes-inventory-components.search.title', value: 'title' },
     { label: 'stripes-inventory-components.search.identifierAll', value: 'identifier' },
@@ -132,7 +132,7 @@ export const advancedSearchIndexes = {
     { label: 'stripes-inventory-components.search.allFields', value: 'allFields' },
   ],
   [segments.holdings]: [
-    { label: 'stripes-inventory-components.search.keyword', value: 'keyword' },
+    { label: 'stripes-inventory-components.search.advanced.keyword', value: 'keyword' },
     { label: 'stripes-inventory-components.search.isbn', value: 'isbn' },
     { label: 'stripes-inventory-components.search.issn', value: 'issn' },
     { label: 'stripes-inventory-components.search.callNumberEyeReadable', value: 'holdingsFullCallNumbers' },
@@ -144,7 +144,7 @@ export const advancedSearchIndexes = {
     { label: 'stripes-inventory-components.search.allFields', value: 'allFields' },
   ],
   [segments.items]: [
-    { label: 'stripes-inventory-components.search.item.keyword', value: 'keyword' },
+    { label: 'stripes-inventory-components.search.advanced.keyword', value: 'keyword' },
     { label: 'stripes-inventory-components.search.barcode', value: 'barcode' },
     { label: 'stripes-inventory-components.search.isbn', value: 'isbn' },
     { label: 'stripes-inventory-components.search.issn', value: 'issn' },

--- a/translations/stripes-inventory-components/en.json
+++ b/translations/stripes-inventory-components/en.json
@@ -33,6 +33,7 @@
   "facet.nameType": "Name type",
   "search.keyword": "Keyword (title, contributor, identifier, HRID, UUID)",
   "search.item.keyword": "Keyword (title, contributor, identifier, HRID, UUID, barcode)",
+  "search.advanced.keyword": "Keyword (title, contributor)",
   "search.contributor": "Contributor",
   "search.title": "Title (all)",
   "search.identifierAll": "Identifier (all)",


### PR DESCRIPTION
## Description
Keyword search options in Advanced search should only say "Keyword (title, contributor)" because those are the only fields that are used for searching.

## Screenshots
![image](https://github.com/user-attachments/assets/9f2ed4c4-b00e-4131-ba92-1b389cb59ff0)

## Issues
[UISINVCOMP-70](https://folio-org.atlassian.net/browse/UISINVCOMP-70)