### PR TITLE
UISINVCOMP-70 Added identifiers back to Advanced keyword search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [2.1.0] (IN PROGRESS)
 
 - [UISINVCOMP-40](https://issues.folio.org/browse/UISINVCOMP-40) "startsWith" search by keyword and title should also search for a title that starts with a quotation mark.
-- [UISINVCOMP-70](https://issues.folio.org/browse/UISINVCOMP-70) Change title of Keyword search option of "Advanced search" to remove identifiers.
+- [UISINVCOMP-70](https://issues.folio.org/browse/UISINVCOMP-70) Change title of Keyword search option of "Advanced search" to remove HRID and UUID.
 
 ## [2.0.4] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.4) (2025-05-13)
 

--- a/translations/stripes-inventory-components/en.json
+++ b/translations/stripes-inventory-components/en.json
@@ -33,7 +33,7 @@
   "facet.nameType": "Name type",
   "search.keyword": "Keyword (title, contributor, identifier, HRID, UUID)",
   "search.item.keyword": "Keyword (title, contributor, identifier, HRID, UUID, barcode)",
-  "search.advanced.keyword": "Keyword (title, contributor)",
+  "search.advanced.keyword": "Keyword (title, contributor, identifier)",
   "search.contributor": "Contributor",
   "search.title": "Title (all)",
   "search.identifierAll": "Identifier (all)",


### PR DESCRIPTION
## Description
Keyword search searches by identifiers, so we need to add them to the search option label

## Issues
[UISINVCOMP-70](https://folio-org.atlassian.net/browse/UISINVCOMP-70)