### PR TITLE
UISINVCOMP-72: Append tenant name to all locations in the location facets except those with duplicate ids.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UISINVCOMP-40](https://issues.folio.org/browse/UISINVCOMP-40) "startsWith" search by keyword and title should also search for a title that starts with a quotation mark.
 - [UISINVCOMP-70](https://issues.folio.org/browse/UISINVCOMP-70) Change title of Keyword search option of "Advanced search" to remove HRID and UUID.
+- [UISINVCOMP-72](https://issues.folio.org/browse/UISINVCOMP-72) Append tenant name to all locations in the location facets except those with duplicate ids.
 
 ## [2.0.4] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.4) (2025-05-13)
 

--- a/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.js
+++ b/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.js
@@ -25,11 +25,6 @@ const useLocationsFromAllTenantsQuery = ({ consortiaTenants = [], tenantId }) =>
   const locationsFromAllTenants = useMemo(() => {
     const locationsOfAllTenants = consolidatedLocations?.locations;
 
-    const locationCounts = locationsOfAllTenants?.reduce((acc, location) => {
-      acc[location.name] = (acc[location.name] ?? 0) + 1;
-      return acc;
-    }, {});
-
     // The tenant's name is added in brackets for locations with the same name.
     const locationsWithTenantNameForDuplicates = locationsOfAllTenants?.map(location => {
       const isLocationIdDuplicate = locationsOfAllTenants.filter(_location => _location.id === location.id).length > 1;
@@ -37,7 +32,7 @@ const useLocationsFromAllTenantsQuery = ({ consortiaTenants = [], tenantId }) =>
       // don't add tenant name to locations which have duplicate ids across tenants
       // in future BE will make changes to make sure this doesn't happen, but for now
       // we'll just have to do this
-      if (locationCounts[location.name] > 1 && !isLocationIdDuplicate) {
+      if (!isLocationIdDuplicate) {
         const tenantName = consortiaTenants.find(tenant => tenant.id === location.tenantId)?.name;
 
         return {

--- a/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.test.js
+++ b/lib/queries/useLocationsFromAllTenantsQuery/useLocationsFromAllTenantsQuery.test.js
@@ -46,8 +46,8 @@ describe('useLocationsFromAllTenantsQuery', () => {
       }),
     });
 
-    describe('when location name is not unique', () => {
-      it('should display tenant`s name in parentheses next to the location name that don`t have duplicate ids', async () => {
+    describe('when a location id is unique', () => {
+      it('should display tenant`s name in parentheses next to the location name', async () => {
         useOkapiKy.mockClear().mockReturnValue({
           get: mockGet,
         });
@@ -85,7 +85,7 @@ describe('useLocationsFromAllTenantsQuery', () => {
     const mockGet = jest.fn().mockReturnValue({
       json: () => Promise.resolve({
         locations: [
-          { id: 'location-id', name: 'name-1' },
+          { id: 'location-id', name: 'name-1', tenantId: 'tenant-id-1' },
         ],
       }),
     });
@@ -106,16 +106,17 @@ describe('useLocationsFromAllTenantsQuery', () => {
       expect(mockGet).toHaveBeenCalledWith('search/consortium/locations');
 
       expect(result.current.locationsFromAllTenants).toEqual([
-        { id: 'location-id', name: 'name-1' },
+        { id: 'location-id', name: 'name-1 (College)', tenantId: 'tenant-id-1' },
       ]);
     });
 
-    describe('when location name is not unique', () => {
+    describe('when a location id is unique', () => {
       it('should display tenant`s name in parentheses next to the location name', async () => {
         const locations = [
           { id: 'location-id-1', name: 'name-1', tenantId: 'tenant-id-3' },
           { id: 'location-id-2', name: 'name-2', tenantId: 'tenant-id-1' },
           { id: 'location-id-3', name: 'name-1', tenantId: 'tenant-id-2' },
+          { id: 'location-id-1', name: 'name-4', tenantId: 'tenant-id-4' },
         ];
 
         useOkapiKy.mockReturnValue({
@@ -129,9 +130,10 @@ describe('useLocationsFromAllTenantsQuery', () => {
         await act(() => !result.current.isLoading);
 
         expect(result.current.locationsFromAllTenants).toEqual([
-          { id: 'location-id-1', name: 'name-1 (School)', tenantId: 'tenant-id-3' },
-          { id: 'location-id-2', name: 'name-2', tenantId: 'tenant-id-1' },
+          { id: 'location-id-1', name: 'name-1', tenantId: 'tenant-id-3' },
+          { id: 'location-id-2', name: 'name-2 (College)', tenantId: 'tenant-id-1' },
           { id: 'location-id-3', name: 'name-1 (Professional)', tenantId: 'tenant-id-2' },
+          { id: 'location-id-1', name: 'name-4', tenantId: 'tenant-id-4' },
         ]);
       });
     });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Description
After each location name in the location facets, append with the tenant name, separated by a space, in between parentheses. For example, "General collection (College)". 

Previously, the tenant name was appended only for locations with the same name and with a unique id. Now the tenant name will be appended for all locations except those with duplicate ids.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
 -->

## Issues
[UISINVCOMP-72](https://folio-org.atlassian.net/browse/UISINVCOMP-72)

## Screenshots
![image](https://github.com/user-attachments/assets/ba5a9694-108c-47b4-9030-9f7948ec4909)


## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
