### PR TITLE
UISINVCOMP-74 Inventory : Escape quotes in Basic search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [UISINVCOMP-40](https://issues.folio.org/browse/UISINVCOMP-40) "startsWith" search by keyword and title should also search for a title that starts with a quotation mark.
 - [UISINVCOMP-70](https://issues.folio.org/browse/UISINVCOMP-70) Change title of Keyword search option of "Advanced search" to remove HRID and UUID.
 - [UISINVCOMP-75](https://issues.folio.org/browse/UISINVCOMP-75) Allow tenant to set default columns to display in Inventory results.
+- [UISINVCOMP-74](https://issues.folio.org/browse/UISINVCOMP-74) Inventory : Escape quotes in Basic search.
 
 ## [2.0.5] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.5) (2025-06-17)
 

--- a/lib/hooks/useFacets/utils.js
+++ b/lib/hooks/useFacets/utils.js
@@ -62,7 +62,7 @@ function buildQuery(queryParams, pathComponents, resourceData, logger) {
     filters,
     2,
     null,
-    false,
+    qindex !== queryIndexes.QUERY_SEARCH,
   )(queryParams, pathComponents, resourceData, logger);
 
   return cql;


### PR DESCRIPTION
## Description
Escape quotes in query for facets. 7th parameter in `makeQueryFunction` is `configOrEscape` which escapes special characters

## Screenshots

https://github.com/user-attachments/assets/c0ca4926-257e-4baf-8452-3dd3272a122f



## Issues
[UISINVCOMP-74](https://folio-org.atlassian.net/browse/UISINVCOMP-74)