### PR TITLE
UISINVCOMP-77 Hide staff suppressed Instances based on existing permission for Staff suppress facet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [UISINVCOMP-75](https://issues.folio.org/browse/UISINVCOMP-75) Allow tenant to set default columns to display in Inventory results.
 - [UISINVCOMP-74](https://issues.folio.org/browse/UISINVCOMP-74) Inventory : Escape quotes in Basic search.
 - [UISINVCOMP-76](https://issues.folio.org/browse/UISINVCOMP-76) Find instance plugin - Adding HRID to the Inventory results list & show columns options.
+- [UISINVCOMP-77](https://issues.folio.org/browse/UISINVCOMP-77) Hide staff suppressed Instances based on existing permission for Staff suppress facet.
 
 ## [2.0.5] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.5) (2025-06-17)
 

--- a/lib/components/InstanceFilters/InstanceFilters.js
+++ b/lib/components/InstanceFilters/InstanceFilters.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { useStripes } from '@folio/stripes/core';
+import { IfPermission, useStripes } from '@folio/stripes/core';
 
 import { SharedFacet } from '../SharedFacet';
 import { HeldByFacet } from '../HeldByFacet';
@@ -132,15 +132,17 @@ const InstanceFilters = ({
         onChange={onChange}
         onToggle={onToggleAccordion}
       />
-      <StaffSuppressFacet
-        name={FACETS.STAFF_SUPPRESS}
-        facetOptions={facetOptions}
-        accordionsStatus={accordionsStatus}
-        activeFilters={activeFilters}
-        getIsLoading={getIsLoading}
-        onChange={onChange}
-        onToggle={onToggleAccordion}
-      />
+      <IfPermission perm="ui-inventory.instance.staff-suppressed-records.view">
+        <StaffSuppressFacet
+          name={FACETS.STAFF_SUPPRESS}
+          facetOptions={facetOptions}
+          accordionsStatus={accordionsStatus}
+          activeFilters={activeFilters}
+          getIsLoading={getIsLoading}
+          onChange={onChange}
+          onToggle={onToggleAccordion}
+        />
+      </IfPermission>
       <DiscoverySuppressFacet
         name={FACETS.INSTANCES_DISCOVERY_SUPPRESS}
         facetOptions={facetOptions}

--- a/lib/hooks/useFacets/useFacets.js
+++ b/lib/hooks/useFacets/useFacets.js
@@ -7,12 +7,15 @@ import {
 } from 'react';
 import omit from 'lodash/omit';
 
+import { useStripes } from '@folio/stripes/core';
+
 import { useFacetsQuery } from './useFacetsQuery';
 import { useFacetOptions } from './useFacetOptions';
+import { getCqlQuery } from './utils';
 import {
-  getCqlQuery,
-} from './utils';
-import { FACETS_TO_REQUEST } from '../../constants';
+  FACETS_TO_REQUEST,
+  FACETS,
+} from '../../constants';
 import { getCurrentFilters } from '../../utils';
 
 const useFacets = ({
@@ -23,6 +26,7 @@ const useFacets = ({
   tenantId = null,
   segment = null,
 }) => {
+  const stripes = useStripes();
   const { qindex } = query;
 
   const [accordionsStatus, setAccordionsStatus] = useState(initialAccordionStates);
@@ -40,6 +44,11 @@ const useFacets = ({
 
   const cqlQuery = useMemo(() => {
     const queryObj = omit(query, ['sort']);
+
+    if (!stripes.hasPerm('ui-inventory.instance.staff-suppressed-records.view')) {
+      queryObj.filters = `${queryObj.filters},${FACETS.STAFF_SUPPRESS}.false`;
+    }
+
     return getCqlQuery(isBrowseLookup, queryObj, data, segment);
   }, [isBrowseLookup, query, data, segment]);
 


### PR DESCRIPTION
## Description
Users without "Inventory: Enable staff suppress facet" permission should not see "Staff suppress" facet. Staff suppress: false should also be automatically applied in all searches by default.

## Related PRs
https://github.com/folio-org/ui-inventory/pull/2875

## Issues
[UISINVCOMP-77](https://folio-org.atlassian.net/browse/UISINVCOMP-77)