### PR TITLE
UISINVCOMP-79 Populate package.json's description field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@folio/stripes-inventory-components",
   "version": "2.1.0",
-  "description": "",
+  "description": "Shared components for inventory-related modules",
   "main": "index.js",
   "license": "Apache-2.0",
   "stripes": {


### PR DESCRIPTION
Populate `package.json`'s `description` field, like every other package does. Strictly speaking, this isn't a requirement, but some uncareful tools expect this value to be present.

Refs [UISINVCOMP-79](https://folio-org.atlassian.net/browse/UISINVCOMP-79)