### PR TITLE
UISINVCOMP-81 ECS: Set Held by facet default to current tenant context in Inventory Search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [UISINVCOMP-74](https://issues.folio.org/browse/UISINVCOMP-74) Inventory : Escape quotes in Basic search.
 - [UISINVCOMP-76](https://issues.folio.org/browse/UISINVCOMP-76) Find instance plugin - Adding HRID to the Inventory results list & show columns options.
 - [UISINVCOMP-77](https://issues.folio.org/browse/UISINVCOMP-77) Hide staff suppressed Instances based on existing permission for Staff suppress facet.
+- [UISINVCOMP-81](https://issues.folio.org/browse/UISINVCOMP-81) ECS: Set Held by facet default to current tenant context in Inventory Search.
 
 ## [2.0.5] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.5) (2025-06-17)
 

--- a/lib/buildSearchQuery/buildSearchQuery.js
+++ b/lib/buildSearchQuery/buildSearchQuery.js
@@ -23,6 +23,11 @@ export const buildSearchQuery = (applyDefaultFilters = noop) => (queryParams, pa
   const segment = queryParams.segment || props.segment || segments.instances;
   const { indexes, sortMap, filters } = filterConfig[segment];
   const query = { ...resourceData.query };
+
+  if (query._isInitial === 'true') {
+    return null;
+  }
+
   const defaultQindex = getDefaultQindex(segment);
   const queryIndex = (!isEmpty(queryParams) && (queryParams.qindex || defaultQindex))
     || props?.resources?.query?.qindex || defaultQindex;


### PR DESCRIPTION
## Description
ECS: Set Held by facet default to current tenant context in Inventory Search.

Add a new url parameter `_isInitial` that, if set to true, will prevent search requests. Can be used to set default values for facets without triggering a search on page load.

## Related PRs
https://github.com/folio-org/ui-inventory/pull/2879

## Issues
[UISINVCOMP-81](https://folio-org.atlassian.net/browse/UISINVCOMP-81)