### PR TITLE
UISINVCOMP-80 Update LCCN search option to search the new cancelled LCCN search index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [UISINVCOMP-74](https://issues.folio.org/browse/UISINVCOMP-74) Inventory : Escape quotes in Basic search.
 - [UISINVCOMP-76](https://issues.folio.org/browse/UISINVCOMP-76) Find instance plugin - Adding HRID to the Inventory results list & show columns options.
 - [UISINVCOMP-82](https://issues.folio.org/browse/UISINVCOMP-82) Don't apply default Staff suppress facet for Browse.
+- [UISINVCOMP-80](https://issues.folio.org/browse/UISINVCOMP-80) Update LCCN search option to search the new cancelled LCCN search index.
 
 ## [2.0.7] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.7) (2025-09-08)
 

--- a/lib/constants/fieldSearchConfigurations.js
+++ b/lib/constants/fieldSearchConfigurations.js
@@ -30,10 +30,10 @@ export const fieldSearchConfigurations = {
     containsAny: 'issn any "*%{query.query}*"',
   },
   lccn: {
-    exactPhrase: 'lccn=="%{query.query}"',
-    containsAll: 'lccn="*%{query.query}*"',
-    startsWith: 'lccn="%{query.query}*"',
-    containsAny: 'lccn any "*%{query.query}*"',
+    exactPhrase: 'lccn=="%{query.query}" or canceledLccn=="%{query.query}"',
+    containsAll: 'lccn="*%{query.query}*" or canceledLccn="*%{query.query}*"',
+    startsWith: 'lccn="%{query.query}*" or canceledLccn="%{query.query}*"',
+    containsAny: 'lccn any "*%{query.query}*" or canceledLccn any "*%{query.query}*"',
   },
   identifier: {
     exactPhrase: 'identifiers.value=="%{query.query}"',

--- a/lib/filterConfig.js
+++ b/lib/filterConfig.js
@@ -167,7 +167,7 @@ export const queryIndexesMap = {
   [queryIndexes.NORMALIZED_CLASSIFICATION_NUMBER]: { label: 'stripes-inventory-components.search.normalizedClassificationNumber', value: queryIndexes.NORMALIZED_CLASSIFICATION_NUMBER, queryTemplate: 'normalizedClassificationNumber=="%{query.query}"' },
   [queryIndexes.ISBN]: { label: 'stripes-inventory-components.search.isbn', value: queryIndexes.ISBN, queryTemplate: 'isbn="%{query.query}"' },
   [queryIndexes.ISSN]: { label: 'stripes-inventory-components.search.issn', value: queryIndexes.ISSN, queryTemplate: 'issn="%{query.query}"' },
-  [queryIndexes.LCCN]: { label: 'stripes-inventory-components.search.lccn', value: queryIndexes.LCCN, queryTemplate: 'lccn="%{query.query}"' },
+  [queryIndexes.LCCN]: { label: 'stripes-inventory-components.search.lccn', value: queryIndexes.LCCN, queryTemplate: 'lccn="%{query.query}" or canceledLccn="%{query.query}"' },
   [queryIndexes.OCLC]: { label: 'stripes-inventory-components.search.oclc', value: queryIndexes.OCLC, queryTemplate: 'oclc="%{query.query}"' },
   [queryIndexes.INSTANCE_NOTES]: { label: 'stripes-inventory-components.search.instanceNotes', value: queryIndexes.INSTANCE_NOTES, queryTemplate: 'notes.note all "%{query.query}" or administrativeNotes all "%{query.query}"' },
   [queryIndexes.INSTANCE_ADMINISTRATIVE_NOTES]: { label: 'stripes-inventory-components.search.instanceAdministrativeNotes', value: queryIndexes.INSTANCE_ADMINISTRATIVE_NOTES, queryTemplate: 'administrativeNotes all "%{query.query}"' },


### PR DESCRIPTION
## Description
LCCN index has been split into two: lccn and canceledLccn. We need to change our search parameters to search by both.

## Issues
[UISINVCOMP-80](https://folio-org.atlassian.net/browse/UISINVCOMP-80)