### PR TITLE
UISINVCOMP-90 Apply `allowUndefinedRecords` parameter to records manifest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [UISINVCOMP-76](https://issues.folio.org/browse/UISINVCOMP-76) Find instance plugin - Adding HRID to the Inventory results list & show columns options.
 - [UISINVCOMP-82](https://issues.folio.org/browse/UISINVCOMP-82) Don't apply default Staff suppress facet for Browse.
 - [UISINVCOMP-80](https://issues.folio.org/browse/UISINVCOMP-80) Update LCCN search option to search the new cancelled LCCN search index.
+- [UISINVCOMP-90](https://issues.folio.org/browse/UISINVCOMP-90) Apply `allowUndefinedRecords` parameter to records manifest.
 
 ## [2.0.7] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.7) (2025-09-08)
 

--- a/lib/buildRecordsManifest/buildRecordsManifest.js
+++ b/lib/buildRecordsManifest/buildRecordsManifest.js
@@ -10,6 +10,7 @@ export const buildRecordsManifest = (applyDefaultFilters) => {
     path: 'inventory/instances',
     resultDensity: 'sparse',
     accumulate: 'true',
+    allowUndefinedRecords: true,
     tenant: '!{tenantId}',
     GET: {
       path: 'search/instances',

--- a/lib/hooks/useFacets/useFacetOptions/useFacetOptions.js
+++ b/lib/hooks/useFacets/useFacetOptions/useFacetOptions.js
@@ -82,7 +82,7 @@ const useFacetOptions = ({ activeFilters, qindex, isBrowseLookup, data, facetsDa
 
   const facetOptions = useMemo(() => {
     return Object.keys(facetsData).reduce((acc, facetCql) => {
-      const options = optionsMap[facetCql](facetsData[facetCql].values);
+      const options = optionsMap[facetCql](facetsData[facetCql].values || []);
 
       if (options) {
         acc[facetCql] = options;


### PR DESCRIPTION
## Description
Apply `allowUndefinedRecords` parameter to records manifest.
Set a fallback `[]` value to facets data to prevent page crash when opening a facet when 0 records are found

## Issues
[UISINVCOMP-90](https://folio-org.atlassian.net/browse/UISINVCOMP-90)