### PR TITLE
UISINVCOMP-91 Remove default "expandAll=true" parameter from Instance Search requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [UISINVCOMP-82](https://issues.folio.org/browse/UISINVCOMP-82) Don't apply default Staff suppress facet for Browse.
 - [UISINVCOMP-80](https://issues.folio.org/browse/UISINVCOMP-80) Update LCCN search option to search the new cancelled LCCN search index.
 - [UISINVCOMP-90](https://issues.folio.org/browse/UISINVCOMP-90) Apply `allowUndefinedRecords` parameter to records manifest.
+- [UISINVCOMP-91](https://issues.folio.org/browse/UISINVCOMP-91) Remove default "expandAll=true" parameter from Instance Search requests.
 
 ## [2.0.8] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.8) (2025-09-17)
 

--- a/lib/buildRecordsManifest/buildRecordsManifest.js
+++ b/lib/buildRecordsManifest/buildRecordsManifest.js
@@ -15,7 +15,6 @@ export const buildRecordsManifest = (applyDefaultFilters) => {
     GET: {
       path: 'search/instances',
       params: {
-        expandAll: true,
         query: buildSearchQuery(applyDefaultFilters),
       },
     },


### PR DESCRIPTION
## Description
Continuing with work related to removing unneeded Instance fields from mod-search response. `expandAll=true` will cause all fields to be returned, so we need to remove this parameter

## Issues
[UISINVCOMP-91](https://folio-org.atlassian.net/browse/UISINVCOMP-91)
