### PR TITLE
UISINVCOMP-101 Wrap advanced search parameters in parentheses to avoid ambiguous boolean operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [UISINVCOMP-94](https://issues.folio.org/browse/UISINVCOMP-94) Escape backslashes ("\") in Contributors during browsing and switching from browse to search.
 - [UISINVCOMP-100](https://issues.folio.org/browse/UISINVCOMP-100) Add identifiers.value as an explicit keyword search option.
 - [UISINVCOMP-83](https://issues.folio.org/browse/UISINVCOMP-83) Migrate to shared CI workflows.
+- [UISINVCOMP-101](https://issues.folio.org/browse/UISINVCOMP-101) Wrap advanced search parameters in parentheses to avoid ambiguous boolean operations.
 
 ## [2.0.9] (https://github.com/folio-org/stripes-inventory-components/tree/v2.0.9) (2026-01-05)
 

--- a/lib/buildSearchQuery/buildSearchQuery.test.js
+++ b/lib/buildSearchQuery/buildSearchQuery.test.js
@@ -82,7 +82,7 @@ describe('buildSearchQuery', () => {
         const cql = buildSearchQuery(noop)(...getBuildQueryArgs({ queryParams }));
 
         expect(cql).toContain(
-          '(keyword all "test" or title=="hello")'
+          '((keyword all "test") or (title=="hello"))'
         );
       });
 

--- a/lib/hooks/useFacets/useFacets.test.js
+++ b/lib/hooks/useFacets/useFacets.test.js
@@ -556,7 +556,7 @@ describe('useFacets', () => {
       expect(mockGet).toHaveBeenCalledWith('search/instances/facets', {
         searchParams: {
           facet: FACETS_CQL.SHARED,
-          query: 'isbn="*test1*" or title=="test2" or keyword all "test3*" or keyword all "\\"test3*"',
+          query: '(isbn="*test1*") or (title=="test2") or (keyword all "test3*" or keyword all "\\"test3*")',
         },
       });
     });

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -67,12 +67,12 @@ export const getAdvancedSearchTemplate = (queryValue) => {
     const rowTemplate = getAdvancedSearchQueryTemplate(row.searchOption, row.match, row.query);
 
     if (!rowTemplate) {
-      return acc;
+      return `(${acc})`;
     }
 
     const rowQuery = rowTemplate.replaceAll('%{query.query}', row.query);
 
-    const formattedRow = `${row.bool} ${rowQuery}`.trim();
+    const formattedRow = `${row.bool} (${rowQuery})`.trim();
     return `${acc} ${formattedRow}`;
   }, '').trim();
 };

--- a/lib/utils/utils.test.js
+++ b/lib/utils/utils.test.js
@@ -63,14 +63,14 @@ describe('utils', () => {
     it('should escape quotes', () => {
       const query = getAdvancedSearchTemplate('title startsWith "Seeing-Eye"');
 
-      expect(query).toBe('title all "\\"Seeing-Eye\\"*" or title all "\\"\\"Seeing-Eye\\"*"');
+      expect(query).toBe('(title all "\\"Seeing-Eye\\"*" or title all "\\"\\"Seeing-Eye\\"*")');
     });
 
     describe('when searching by title', () => {
       it('should also add a quote at the beginning', () => {
         const query = getAdvancedSearchTemplate('title startsWith Seeing-Eye"');
 
-        expect(query).toBe('title all "Seeing-Eye\\"*" or title all "\\"Seeing-Eye\\"*"');
+        expect(query).toBe('(title all "Seeing-Eye\\"*" or title all "\\"Seeing-Eye\\"*")');
       });
     });
 
@@ -78,7 +78,7 @@ describe('utils', () => {
       it('should also add a quote at the beginning', () => {
         const query = getAdvancedSearchTemplate('keyword startsWith Seeing-Eye"');
 
-        expect(query).toBe('keyword all "Seeing-Eye\\"*" or keyword all "\\"Seeing-Eye\\"*"');
+        expect(query).toBe('(keyword all "Seeing-Eye\\"*" or keyword all "\\"Seeing-Eye\\"*")');
       });
     });
   });


### PR DESCRIPTION
## Description
Some search fields in Advanced Search are composite, meaning searching by that field will query 2 or more BE indexes. For example, "Instance notes (all)" is formatted as `notes.note all "term" or administrativeNotes all "term"`
If we then search by several advanced search fields then all of these boolean operators can get mixed up and cause ambiguous operations.
For example: `(lccn="term1*" or canceledLccn="term1*" and notes.note all "term2" or administrativeNotes all "term2" and isbn="*term3*")` - should be `((lccn="term1*" or canceledLccn="term1*") and (notes.note all "term2" or administrativeNotes all "term2") and (isbn="*term3*"))`

To fix this we need to additionally wrap these search fields in parentheses.

## Issues
[UISINVCOMP-101](https://folio-org.atlassian.net/browse/UISINVCOMP-101)